### PR TITLE
Use virtual offset for GetPlayerMaxSpeed SDK call (thanks sneaK)

### DIFF
--- a/addons/sourcemod/gamedata/movementapi.games.txt
+++ b/addons/sourcemod/gamedata/movementapi.games.txt
@@ -2,13 +2,13 @@
 {
 	"csgo"
 	{
-		"Signatures"
+		"Offsets"
 		{
 			"GetPlayerMaxSpeed"
 			{
-				"library"	"server"
-				"windows"	"\x55\x8B\xEC\x83\xEC\x08\x56\x8B\xF1\x80\xBE\xE2\x00\x00\x00\x00"
-				"linux"		"\x55\x89\xE5\x83\xEC\x38\x89\x5D\xF8\x8B\x5D\x08\x89\x75\xFC\x80\xBB\xEA\x00\x00\x00\x00"
+				"windows"	"504"
+				"linux"		"505"
+				"mac"		"505"
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/movementapi.sp
+++ b/addons/sourcemod/scripting/movementapi.sp
@@ -12,7 +12,7 @@ public Plugin myinfo =
 	name = "MovementAPI", 
 	author = "DanZay", 
 	description = "Provides API focused on player movement", 
-	version = "1.1.2", 
+	version = "1.1.3", 
 	url = "https://github.com/danzayau/MovementAPI"
 };
 
@@ -134,7 +134,7 @@ static void PrepSDKCalls()
 {
 	gH_GameData = LoadGameConfigFile("movementapi.games");
 	StartPrepSDKCall(SDKCall_Player);
-	PrepSDKCall_SetFromConf(gH_GameData, SDKConf_Signature, "GetPlayerMaxSpeed");
+	PrepSDKCall_SetFromConf(gH_GameData, SDKConf_Virtual, "GetPlayerMaxSpeed");
 	PrepSDKCall_SetReturnInfo(SDKType_Float, SDKPass_ByValue);
 	gH_GetMaxSpeed = EndPrepSDKCall();
 }


### PR DESCRIPTION
Use virtual offset because the signature broke with the Danger Zone update.

Resolves #13 