### PR TITLE
MovementAPI update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.smx
+.vscode/

--- a/README.md
+++ b/README.md
@@ -17,5 +17,13 @@ A SourceMod API focused on player movement in the form of a [function stock liba
  * **Takeoff** - Becoming airborne, including jumping, falling, getting off a ladder and leaving noclip.
  * **Landing** - Leaving the air, including landing on the ground, grabbing a ladder and entering noclip.
  * **Perfect Bunnyhop (Perf)** - When the player has jumped in the tick after landing and keeps their speed.
- * **Jumpbug** - When the player is never seen as 'on ground' when bunnyhopping. This is achievable by uncrouching and jumping at the same time. A jumpbug results in unusual behaviour such as maintaining horizontal speed and not receiving fall damage.
- * **Distbug** - A distbug can occur when a player lands close to the edge of a block. When calculating the landing position, the source engine will only consider either the horizontal or vertical speed on the very last tick, but not both. The GetNobugLandingOrigin calculates the correct landing position of the player based on his actual trajectory using all components of the velocity instead.
+ * **Duckbug/Crouchbug** - When the player sucessfully lands due to uncrouching from mid air and not by falling down. This causes no stamina loss or fall damage upon landing.
+ * **Jumpbug** - This is achieved by duckbugging and jumping at the same time. The player is never seen as 'on ground' when bunnyhopping from a tick by tick perspective. A jumpbug inherits the same behavior as a duckbug/crouchbug, along with its effects such as maintaining speed due to no stamina loss.
+ * **Distbug** - Landing behavior varies depending on whether the player lands close to the edge of a block or not:
+
+    1. If the player lands close to the edge of a block, this causes the jump duration to be one tick longer and the player can "slide" on the ground during the landing tick, using the position post-tick as landing position becomes inaccurate.
+    2. On the other hand, if the player does not land close to the edge, the player will be considered on the ground one tick earlier, using this position as landing position is not accurate as the player has yet to be fully on the ground.
+ 
+    - In scenario 1, GetNobugLandingOrigin calculates the correct landing position of the player before the sliding effect takes effect.
+
+    - In scenario 2, GetNobugLandingOrigin attempts extrapolate the player's fully on ground position to make landing positions consistent across scenarios.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A SourceMod API focused on player movement in the form of a [function stock liba
 ### Requirements
 
  * SourceMod ^1.10
+ * [DHooks 2 with detour support](https://github.com/peace-maker/DHooks2)
  
 ### Plugin Installation
 

--- a/addons/sourcemod/gamedata/movementapi.games.txt
+++ b/addons/sourcemod/gamedata/movementapi.games.txt
@@ -2,6 +2,88 @@
 {
 	"csgo"
 	{
+		"Keys"
+		{
+			"CGameMovement::player"				"4"
+			"CGameMovement::mv"					"8"
+			"CMoveData::m_vecViewAngles"		"12"
+			"CMoveData::m_vecVelocity"			"64"
+			"CMoveData::m_vecAbsOrigin"			"172"
+		}
+		"Functions"
+		{
+			"CCSGameMovement::PlayerMove"
+			{
+				"signature" "CCSGameMovement::PlayerMove"
+				"callconv"	"thiscall"
+				"this"		"address"
+				"return"	"void"
+			}
+			"CGameMovement::AirAccelerate"
+			{
+				"signature" "CGameMovement::AirAccelerate"
+				"callconv"  "thiscall"
+				"this"      "address"
+				"return"    "void"
+				"arguments"
+				{
+					"wishdir"
+					{
+						"type"	"vectorptr"
+					}
+					"wishspeed"
+					{
+						"type"	"float"
+					}
+					"sv_airaccelerate"
+					{
+						"type"	"float"
+					}
+				}
+			}
+			"CGameMovement::LadderMove"
+			{
+				"signature" "CGameMovement::LadderMove"
+				"callconv"	"thiscall"
+				"this"		"address"
+				"return" 	"bool"
+			}
+			"CCSGameMovement::Duck"
+			{
+				"signature" "CCSGameMovement::Duck"
+				"callconv"  "thiscall"
+				"this"      "address"
+				"return"    "void"				
+			}
+			"CGameMovement::WalkMove"
+			{
+				"signature" "CGameMovement::WalkMove"
+				"callconv" 	"thiscall"
+				"this" 		"address"
+				"return" 	"void"
+			}
+			"CGameMovement::FullLadderMove"
+			{
+				"signature" "CGameMovement::FullLadderMove"
+				"callconv" 	"thiscall"
+				"this" 		"address"
+				"return" 	"void"
+			}
+			"CCSGameMovement::OnJump"
+			{
+				"signature" "CCSGameMovement::OnJump"
+				"callconv"	"thiscall"
+				"this"		"address"
+				"return"	"void"
+				"arguments"
+				{
+					"impulse"
+					{
+						"type"	"float"
+					}
+				}
+			}
+		}
 		"Offsets"
 		{
 			"GetPlayerMaxSpeed"
@@ -9,6 +91,51 @@
 				"windows"	"505"
 				"linux"		"506"
 				"mac"		"506"
+			}
+		}
+		"Signatures"
+		{
+			"CCSGameMovement::PlayerMove"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x18\x57\x8B\xF9\x8B\x8F\x54\x0E\x00\x00"
+				"linux"		"\x55\x89\xE5\x56\x53\x83\xEC\x50\x8B\x5D\x08\x8B\x83\x54\x0E\x00\x00"
+			}
+			"CGameMovement::WalkMove"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x81\xEC\x9C\x00\x00\x00\x56\x57\x8B\xF9\xC7\x45\xB0\x00\x00\x00\x00"
+				"linux"		"\x55\x89\xE5\x57\x56\x8D\x45\xDC\xBE\xFF\xFF\xFF\xFF"
+			}
+			"CGameMovement::AirAccelerate"
+			{
+				"library" 	"server"
+				"windows" 	"\x55\x8B\xEC\x83\xEC\x20\x56\x57\x8B\xF9\x8B\x77\x04"
+				"linux"		"\x55\x89\xE5\x57\x56\x53\x81\xEC\xAC\x00\x00\x00\x8B\x75\x08\x8B\x7D\x0C\x8B\x5E\x04"
+			}
+			"CGameMovement::LadderMove"
+			{
+				"library" 	"server"
+				"windows" 	"\x55\x8B\xEC\x83\xE4\xF8\x81\xEC\xD8\x00\x00\x00\x56\x57\x8B\xF9"
+				"linux"		"\x55\x89\xE5\x57\x56\x53\x81\xEC\x2C\x01\x00\x00\xC7\x45\x98\x00\x00\x00\x00"
+			}
+			"CCSGameMovement::Duck"
+			{
+				"library" 	"server"
+				"windows" 	"\x55\x8B\xEC\x81\xEC\x88\x00\x00\x00\x56\x57\x8B\xF9\x8B\x57\x04"
+				"linux"		"\x55\x89\xE5\x57\x56\x53\x81\xEC\xFC\x00\x00\x00\x8B\x5D\x08\x8B\x43\x04"
+			}
+			"CGameMovement::FullLadderMove"
+			{
+				"library" 	"server"
+				"windows" 	"\x56\x8B\xF1\x8B\x06\xFF\x90\xC8\x00\x00\x00"
+				"linux"		"\x55\x89\xE5\x53\x83\xEC\x14\x8B\x5D\x08\x8B\x03\x89\x1C\x24\xFF\x90\xCC\x00\x00\x00"
+			}
+			"CCSGameMovement::OnJump"
+			{
+				"library" 	"server"
+				"windows" 	"\x55\x8B\xEC\x83\xEC\x0C\x56\x57\x8B\xF9\x8B\x87\x54\x0E\x00\x00"
+				"linux"		"\x55\x89\xE5\x57\x56\x53\x83\xEC\x4C\x8B\x75\x08\xF3\x0F\x10\x45\x0C\xF3\x0F\x11\x45\xE4\x8B\x86\x54\x0E\x00\x00"
 			}
 		}
 	}

--- a/addons/sourcemod/gamedata/movementapi.games.txt
+++ b/addons/sourcemod/gamedata/movementapi.games.txt
@@ -83,6 +83,13 @@
 					}
 				}
 			}
+			"CGameMovement::CategorizePosition"
+			{
+				"signature" "CGameMovement::CategorizePosition"
+				"callconv" 	"thiscall"
+				"this" 		"address"
+				"return" 	"void"
+			}
 		}
 		"Offsets"
 		{
@@ -136,6 +143,12 @@
 				"library" 	"server"
 				"windows" 	"\x55\x8B\xEC\x83\xEC\x0C\x56\x57\x8B\xF9\x8B\x87\x54\x0E\x00\x00"
 				"linux"		"\x55\x89\xE5\x57\x56\x53\x83\xEC\x4C\x8B\x75\x08\xF3\x0F\x10\x45\x0C\xF3\x0F\x11\x45\xE4\x8B\x86\x54\x0E\x00\x00"
+			}
+			"CGameMovement::CategorizePosition"
+			{
+				"library"	"server"
+				"windows"	"\x55\x8B\xEC\x83\xEC\x78\x57"
+				"linux"		"\x55\x89\xE5\x57\x56\x53\x81\xEC\xFC\x00\x00\x00\xC7\x45\xC4\x00\x00\x00\x00"
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/include/dhooks.inc
+++ b/addons/sourcemod/scripting/include/dhooks.inc
@@ -1,0 +1,1015 @@
+#if defined _dhooks_included
+#endinput
+#endif
+#define _dhooks_included
+
+// Needed for the SDKFuncConfSource enum.
+#include <sdktools>
+
+#define INVALID_HOOK_ID 0
+
+enum ObjectValueType
+{
+	ObjectValueType_Int = 0,
+	ObjectValueType_Bool,
+	ObjectValueType_Ehandle,
+	ObjectValueType_Float,
+	ObjectValueType_CBaseEntityPtr,
+	ObjectValueType_IntPtr,
+	ObjectValueType_BoolPtr,
+	ObjectValueType_EhandlePtr,
+	ObjectValueType_FloatPtr,
+	ObjectValueType_Vector,
+	ObjectValueType_VectorPtr,
+	ObjectValueType_CharPtr,
+	ObjectValueType_String
+};
+
+enum ListenType
+{
+	ListenType_Created,
+	ListenType_Deleted
+};
+
+enum ReturnType
+{
+	ReturnType_Unknown,
+	ReturnType_Void,
+	ReturnType_Int,
+	ReturnType_Bool,
+	ReturnType_Float,
+	ReturnType_String, //Note this is a string_t
+	ReturnType_StringPtr, //Note this is a string_t *
+	ReturnType_CharPtr,
+	ReturnType_Vector,
+	ReturnType_VectorPtr,
+	ReturnType_CBaseEntity,
+	ReturnType_Edict
+};
+
+enum HookParamType
+{
+	HookParamType_Unknown,
+	HookParamType_Int,
+	HookParamType_Bool,
+	HookParamType_Float,
+	HookParamType_String, //Note this is a string_t
+	HookParamType_StringPtr, //Note this is a string_t *
+	HookParamType_CharPtr,
+	HookParamType_VectorPtr,
+	HookParamType_CBaseEntity,
+	HookParamType_ObjectPtr,
+	HookParamType_Edict,
+	HookParamType_Object
+};
+
+enum ThisPointerType
+{
+	ThisPointer_Ignore,
+	ThisPointer_CBaseEntity,
+	ThisPointer_Address
+};
+
+enum HookType
+{
+	HookType_Entity,
+	HookType_GameRules,
+	HookType_Raw
+};
+
+enum CallingConvention
+{
+	CallConv_CDECL,
+	CallConv_THISCALL,
+	CallConv_STDCALL,
+	CallConv_FASTCALL,
+};
+
+enum HookMode
+{
+	Hook_Pre,                   // Callback will be executed BEFORE the original function.
+	Hook_Post                   // Callback will be executed AFTER the original function.
+};
+
+enum MRESReturn
+{
+	MRES_ChangedHandled = -2,	// Use changed values and return MRES_Handled
+	MRES_ChangedOverride,		// Use changed values and return MRES_Override
+	MRES_Ignored,				// plugin didn't take any action
+	MRES_Handled,				// plugin did something, but real function should still be called
+	MRES_Override,				// call real function, but use my return value
+	MRES_Supercede				// skip real function; use my return value
+};
+
+enum DHookPassFlag
+{
+	DHookPass_ByVal = 		(1<<0),		/**< Passing by value */
+	DHookPass_ByRef = 		(1<<1),		/**< Passing by reference */
+	DHookPass_ODTOR =		(1<<2),		/**< Object has a destructor */
+	DHookPass_OCTOR =		(1<<3),		/**< Object has a constructor */
+	DHookPass_OASSIGNOP	=	(1<<4),		/**< Object has an assignment operator */
+};
+
+enum DHookRegister
+{
+	// Don't change the register and use the default for the calling convention.
+	DHookRegister_Default,
+	
+	// 8-bit general purpose registers
+	DHookRegister_AL,
+	DHookRegister_CL,
+	DHookRegister_DL,
+	DHookRegister_BL,
+	DHookRegister_AH,
+	DHookRegister_CH,
+	DHookRegister_DH,
+	DHookRegister_BH,
+	
+	// 32-bit general purpose registers
+	DHookRegister_EAX,
+	DHookRegister_ECX,
+	DHookRegister_EDX,
+	DHookRegister_EBX,
+	DHookRegister_ESP,
+	DHookRegister_EBP,
+	DHookRegister_ESI,
+	DHookRegister_EDI,
+	
+	// 128-bit XMM registers
+	DHookRegister_XMM0,
+	DHookRegister_XMM1,
+	DHookRegister_XMM2,
+	DHookRegister_XMM3,
+	DHookRegister_XMM4,
+	DHookRegister_XMM5,
+	DHookRegister_XMM6,
+	DHookRegister_XMM7,
+	
+	// 80-bit FPU registers
+	DHookRegister_ST0
+};
+
+typeset ListenCB
+{
+	//Deleted
+	function void (int entity);
+	
+	//Created
+	function void (int entity, const char[] classname);
+};
+
+typeset DHookRemovalCB
+{
+	function void (int hookid);
+};
+typeset DHookCallback
+{
+	//Function Example: void Ham::Test() with this pointer ignore
+	function MRESReturn ();
+	
+	//Function Example: void Ham::Test() with this pointer passed
+	function MRESReturn (int pThis);
+	
+	//Function Example: void Ham::Test(int cake) with this pointer ignore
+	function MRESReturn (DHookParam hParams);
+	
+	//Function Example: void Ham::Test(int cake) with this pointer passed
+	function MRESReturn (int pThis, DHookParam hParams);
+	
+	//Function Example: int Ham::Test() with this pointer ignore
+	function MRESReturn (DHookReturn hReturn);
+	
+	//Function Example: int Ham::Test() with this pointer passed
+	function MRESReturn (int pThis, DHookReturn hReturn);
+	
+	//Function Example: int Ham::Test(int cake) with this pointer ignore
+	function MRESReturn (DHookReturn hReturn, DHookParam hParams);
+	
+	//Function Example: int Ham::Test(int cake) with this pointer passed
+	function MRESReturn (int pThis, DHookReturn hReturn, DHookParam hParams);
+	
+	//Address NOW
+	
+	//Function Example: void Ham::Test() with this pointer passed
+	function MRESReturn (Address pThis);
+	
+	//Function Example: void Ham::Test(int cake) with this pointer passed
+	function MRESReturn (Address pThis, DHookParam hParams);
+	
+	//Function Example: int Ham::Test() with this pointer passed
+	function MRESReturn (Address pThis, DHookReturn hReturn);
+	
+	//Function Example: int Ham::Test(int cake) with this pointer passed
+	function MRESReturn (Address pThis, DHookReturn hReturn, DHookParam hParams);
+	
+};
+
+// Represents the parameters of the hooked function.
+methodmap DHookParam < Handle
+{
+	// Get the value of a parameter.
+	// Use only for: int, entity, edict, bool or float parameter types.
+	//
+	// @param num           Parameter number to get, starting at 1. Parameter number 0 returns
+	//                      the number of parameters.
+	//
+	// @return              Value if num greater than 0. If 0 returns parameter count.
+	//                      If CBaseEntity returns entity index.
+	// @error               Invalid handle, invalid param number or invalid param type.
+	public native any Get(int num);
+
+	// Get the value of a vector parameter.
+	// Use only for: vector or vectorptr parameter types.
+	//
+	// @param num           Parameter number to get, starting at 1.
+	// @param vec           Vector buffer to store result.
+	//
+	// @error               Invalid handle, invalid param number or invalid param type.
+	public native void GetVector(int num, float vec[3]);
+
+	// Get the value of a string parameter.
+	// Use only for: string, stringptr or charptr parameter types.
+	//
+	// @param num           Parameter number to get, starting at 1.
+	// @param buffer        String buffer to store result.
+	// @param size          Buffer size.
+	// 
+	// @error               Invalid handle, invalid param number or invalid param type.
+	public native void GetString(int num, char[] buffer, int size);
+
+	// Set the value of a parameter.
+	// Use only for: int, entity, edict, bool or float parameter types.
+	//
+	// The changes are only applied when MRES_ChangedHandled or MRES_ChangedOverride
+	// is returned in the callback.
+	//
+	// @param num           Parameter number to set starting at 1.
+	// @param value         Value to set it as (only pass int, bool, float or entity index).
+	//
+	// @error               Invalid handle, invalid param number or invalid param type.
+	public native void Set(int num, any value);
+
+	// Set the value of a vector parameter.
+	// Use only for: vector or vectorptr parameter types.
+	//
+	// The changes are only applied when MRES_ChangedHandled or MRES_ChangedOverride
+	// is returned in the callback.
+	//
+	// @param num           Parameter number to set, starting at 1.
+	// @param vec           Value to set vector as.
+	//
+	// @error               Invalid handle, invalid param number or invalid param type.
+	public native void SetVector(int num, const float vec[3]);
+
+	// Set the value of a string parameter.
+	// Use only for: string, stringptr or charptr parameter types.
+	//
+	// The changes are only applied when MRES_ChangedHandled or MRES_ChangedOverride
+	// is returned in the callback.
+	//
+	// @param num           Parameter number to set, starting at 1.
+	// @param value         Value to set string as.
+	//
+	// @error               Invalid handle, invalid param number or invalid param type.
+	public native void SetString(int num, const char[] value);
+
+	// Gets an object's variable value.
+	//
+	// @param num           Parameter number to get, starting at 1.
+	// @param offset        Byte offset within the object to the var to get.
+	// @param type          Type of var it is.
+	//
+	// @return              Value of the objects var. If EHANDLE type or entity returns entity index.
+	// @error               Invalid handle, invalid param number, invalid param type or invalid Object type.
+	public native any GetObjectVar(int num, int offset, ObjectValueType type);
+
+	// Gets an object's vector variable value.
+	//
+	// @param num           Parameter number to get, starting at 1.
+	// @param offset        Byte offset within the object to the var to get.
+	// @param type          Type of var it is.
+	// @param vec           Buffer to store the result vector.
+	//
+	// @error               Invalid handle, invalid param number, invalid param type or invalid Object type.
+	public native void GetObjectVarVector(int num, int offset, ObjectValueType type, float vec[3]);
+
+	// Gets an object's string variable value.
+	//
+	// @param num           Parameter number to get, starting at 1.
+	// @param offset        Byte offset within the object to the var to get.
+	// @param type          Type of var it is.
+	// @param buffer        Buffer to store the result string.
+	// @param size          Size of the buffer.
+	//
+	// @error               Invalid handle, invalid param number, invalid param type or invalid Object type.
+	public native void GetObjectVarString(int num, int offset, ObjectValueType type, char[] buffer, int size);
+
+	// Sets an object's variable value.
+	//
+	// The changes are only applied when MRES_ChangedHandled or MRES_ChangedOverride
+	// is returned in the callback.
+	//
+	// @param num           Parameter number to set, starting at 1.
+	// @param offset        Byte offset within the object to the var to set.
+	// @param type          Type of var it is.
+	// @param value         The value to set the var to.
+	//
+	// @error               Invalid handle, invalid param number, invalid param type or invalid Object type.
+	public native void SetObjectVar(int num, int offset, ObjectValueType type, any value);
+
+	// Sets an object's vector variable value.
+	//
+	// The changes are only applied when MRES_ChangedHandled or MRES_ChangedOverride
+	// is returned in the callback.
+	//
+	// @param num           Parameter number to set, starting at 1.
+	// @param offset        Byte offset within the object to the var to set.
+	// @param type          Type of var it is.
+	// @param vec           The value to set the vector var to.
+	//
+	// @error               Invalid handle, invalid param number, invalid param type or invalid Object type.
+	public native void SetObjectVarVector(int num, int offset, ObjectValueType type, const float vec[3]);
+
+	// No setter for object strings yet. Open an issue if you really need it.
+
+	// Checks if a pointer parameter is null.
+	//
+	// @param num           Parameter number to check, starting at 1.
+	//
+	// @return              True if null, false otherwise.
+	// @error               Non-pointer parameter.
+	public native bool IsNull(int num);
+};
+
+
+// Represents the return value of the hooked function.
+methodmap DHookReturn < Handle
+{
+ 	// Retrieves or sets the return value.
+ 	// Use only for: int, entity, edict, bool or float return types.
+ 	//
+ 	// The return value is only readable in a post hook.
+ 	// The value is only applied when MRES_Override or MRES_Supercede is returned
+ 	// in the callback.
+	property any Value {
+		public native get();
+		public native set(any value);
+	}
+
+	// Get return vector value.
+	// Use only for: vector or vectorptr return types.
+	//
+	// Only useful in post hooks.
+	//
+	// @param vec           Vector buffer to store result in.
+	//
+	// @error               Invalid Handle or invalid type.
+	public native void GetVector(float vec[3]);
+
+	// Get return string value.
+	// Use only for: string, stringptr or charptr return types.
+	//
+	// Only useful in post hooks.
+	//
+	// @param buffer        String buffer to store result in.
+	// @param size          String buffer size.
+	//
+	// @error               Invalid Handle or invalid type.
+	public native void GetString(char[] buffer, int size);
+
+	// Set return vector value.
+	// Use only for: vector or vectorptr return types.
+	//
+	// The value is only applied when MRES_Override or MRES_Supercede is returned
+ 	// in the callback.
+	//
+	// @param vec           Value to set return vector to.
+	//
+	// @error               Invalid Handle or invalid type.
+	public native void SetVector(const float vec[3]);
+
+	// Set return string value.
+	// Use only for: string, stringptr or charptr return types.
+	//
+	// The value is only applied when MRES_Override or MRES_Supercede is returned
+ 	// in the callback.
+	//
+	// @param buffer        Value to set return string to.
+	//
+	// @error               Invalid Handle or invalid type.
+	public native void SetString(const char[] buffer);
+};
+
+// Base method map for common functions between virtual hooks and detours.
+methodmap DHookSetup < Handle
+{
+	// Load address or offset for a vtable hook or detour from a gamedata file.
+	//
+	// @param gameconf      GameData handle.
+	// @param source        Whether to look in Offsets, Signatures, or Addresses.
+	// @param name          Name of the property to find.
+	//
+	// @return              True on success, false if nothing was found.
+	// @error               Invalid setup or gamedata handle.
+	public native bool SetFromConf(Handle gameconf, SDKFuncConfSource source, const char[] name);
+
+	// Adds a parameter to a hook setup.
+	//
+	// @param type              Parameter type.
+	// @param size              Used for Objects (not Object ptr) to define the size of the object.
+	// @param flag              Used to change the pass type (ignored by detours).
+	// @param custom_register   The register this argument is passed in instead of the stack (ignored by vhooks).
+	// 
+	// @error                   Invalid setup handle or too many params added (request upping the max in thread).
+	public native void AddParam(HookParamType type, int size=-1, DHookPassFlag flag=DHookPass_ByVal, DHookRegister custom_register=DHookRegister_Default);
+};
+
+// A DynamicHook allows to hook a virtual function on any C++ object.
+// Currently CBaseEntity and CGameRules have a convenience API for easy entity hooking,
+// but it's possible to provide a raw this-pointer to hook any object in memory too.
+// 
+// Internally this intercepts function calls by replacing the function pointer
+// in the virtual table of the object with our own function.
+methodmap DynamicHook < DHookSetup
+{
+	// Creates a vtable hook.
+ 	//
+ 	// @param offset        Virtual table offset of function to hook.
+ 	// @param hooktype      Type of hook.
+	// @param returntype    Type of return value.
+	// @param thistype      Type of this pointer or ignore (ignore can be used if not needed).
+	// 
+	// @error               Failed to create hook setup handle or invalid callback function.
+	public native DynamicHook(int offset, HookType hooktype, ReturnType returntype, ThisPointerType thistype);
+
+	// Setup a vtable hook for a function as described in a "Functions" section in gamedata.
+	// The "Functions" section is parsed once the gamedata file is loaded and cached globally.
+	//
+	// @param gameconf      GameData handle to use for address lookup.
+	//                      Doesn't have to be the same as the one with the "Functions" section.
+	// @param name          Name of the function in a "Functions" section to load.
+	//
+	// @return              Setup handle for the detour or null if offset wasn't found.
+	// @error               Failed to create detour setup handle, invalid gamedata handle,
+	//                      invalid callback function or failed to find function in cached "Functions" sections.
+	public static native DynamicHook FromConf(Handle gameconf, const char[] name);
+
+	// Hook an entity.
+	//
+	// Entity hooks are auto-removed when the entity is destroyed.
+	// If you need to read the return value of the function, choose a post hook.
+	//
+	// @param mode          The desired hook mode - pre or post.
+	//                      A pre hook calls your callback BEFORE the original function is called. 
+	//                        You can access the parameters, set the return value, and skip the original function.
+	//                      A post hook calls your callback AFTER the original function executed.
+	//                        You can access the parameters and get/set the return value.
+	// @param entity        Entity index to hook on.
+	// @param callback      Callback function.
+	// @param removalcb     Optional callback for when the hook is removed.
+	// 
+	// @return              A hookid on success, INVALID_HOOK_ID otherwise.
+	// @error               Invalid setup handle, invalid address, invalid hook type or invalid callback.
+	public native int HookEntity(HookMode mode, int entity, DHookCallback callback, DHookRemovalCB removalcb=INVALID_FUNCTION);
+
+	// Hook gamerules object.
+	//
+	// Game rules hooks are auto-removed on map end.
+	// If you need to read the return value of the function, choose a post hook.
+	//
+	// @param mode          The desired hook mode - pre or post.
+	//                      A pre hook calls your callback BEFORE the original function is called. 
+	//                        You can access the parameters, set the return value, and skip the original function.
+	//                      A post hook calls your callback AFTER the original function executed.
+	//                        You can access the parameters and get/set the return value.
+	// @param callback      Callback function.
+	// @param removalcb     Optional callback for when the hook is removed.
+	// 
+	// @return              A hookid on success, INVALID_HOOK_ID otherwise.
+	// @error               Invalid setup handle, invalid address, invalid hook type or invalid callback.
+	public native int HookGamerules(HookMode mode, DHookCallback callback, DHookRemovalCB removalcb=INVALID_FUNCTION);
+
+	// Hook a raw this-pointer.
+	// If you need to read the return value of the function, choose a post hook.
+	//
+	// @param mode          The desired hook mode - pre or post.
+	//                      A pre hook calls your callback BEFORE the original function is called. 
+	//                        You can access the parameters, set the return value, and skip the original function.
+	//                      A post hook calls your callback AFTER the original function executed.
+	//                        You can access the parameters and get/set the return value.
+	// @param addr          This pointer address.
+	// @param callback      Callback function.
+	// 
+	// @return              A hookid on success, INVALID_HOOK_ID otherwise.
+	// @error               Invalid setup handle, invalid address, invalid hook type or invalid callback.
+	public native int HookRaw(HookMode mode, Address addr, DHookCallback callback);
+
+	// Remove hook by hook id:
+	// This will NOT fire the removal callback!
+	// 
+	// @param hookid        Hook id to remove.
+	// 
+	// @return              True on success, false otherwise
+	public static native bool RemoveHook(int hookid);
+};
+
+// A DynamicDetour is a way to hook and block any function in memory.
+// Given the address of a function, it can call a callback in your script whenever
+// the function gets called. The callback has access to all parameters of the function
+// as well as the return value.
+//
+// Internally this works by replacing the first instructions of the function
+// with a jump to our own code. This means that the signature used to find
+// the function address in the first place might not match anymore after a detour.
+// If you need to detour the same function in different plugins make sure to 
+// wildcard \x2a the first 6 bytes of the signature to accommodate for the patched
+// jump introduced by the detour.
+methodmap DynamicDetour < DHookSetup
+{
+	// Creates a detour.
+	//
+	// @param funcaddr      The address of the function to detour.
+	//                      Can be Address_Null if you want to load the address from gamedata using DHookSetFromConf.
+	// @param callConv      Calling convention of the function.
+	// @param returnType    Type of the return value.
+	// @param thisType      Type of this pointer or ignore (ignore can be used if not needed).
+	//                      Only used for thiscall detours.
+	//
+	// @error               Failed to create detour setup handle.
+	public native DynamicDetour(Address funcaddr, CallingConvention callConv, ReturnType returntype, ThisPointerType thisType=ThisPointer_Ignore);
+
+	// Setup a detour for a function as described in a "Functions" section in gamedata.
+	// The "Functions" section is parsed once the gamedata file is loaded and cached globally.
+	//
+	// @param gameconf      GameData handle to use for address lookup.
+	//                      Doesn't have to be the same as the one with the "Functions" section.
+	// @param name          Name of the function in a "Functions" section to load.
+	//
+	// @return              Setup handle for the detour or null if offset wasn't found.
+	// @error               Failed to create detour setup handle, invalid gamedata handle,
+	//                      invalid callback function or failed to find function in cached "Functions" sections.
+	public static native DynamicDetour FromConf(Handle gameconf, const char[] name);
+
+	// Enable the detour of the function described in this detour setup.
+	// If you need to read the return value of the function, choose a post hook.
+	//
+	// @param mode          The desired hook mode - pre or post.
+	//                      A pre hook calls your callback BEFORE the original function is called. 
+	//                        You can access the parameters, set the return value, and skip the original function.
+	//                      A post hook calls your callback AFTER the original function executed.
+	//                        You can access the parameters and get/set the return value.
+	// @param callback      Callback function.
+	//
+	// @return              True if detour was enabled, false otherwise.
+	// @error               Hook handle is not setup for a detour.
+	public native bool Enable(HookMode mode, DHookCallback callback);
+
+	// Disable the detour of the function described in this detour setup.
+	//
+	// @param mode          The hook mode to disable - pre or post.
+	// @param callback      Callback function.
+	//
+	// @return              True if detour was disabled, false otherwise.
+	// @error               Hook handle is not setup for a detour or function is not detoured.
+	public native bool Disable(HookMode mode, DHookCallback callback);
+};
+
+/* Adds an entity listener hook
+ *
+ * @param type			Type of listener to add
+ * @param callback		Callback to use
+ *
+ * @noreturn
+*/
+native void DHookAddEntityListener(ListenType type, ListenCB callback);
+
+/* Removes an entity listener hook
+ *
+ * @param type			Type of listener to remove
+ * @param callback		Callback this listener was using
+ *
+ * @return True if one was removed false otherwise.
+*/
+native bool DHookRemoveEntityListener(ListenType type, ListenCB callback);
+
+/* Creates a hook
+ *
+ * @param offset		vtable offset of function to hook
+ * @param hooktype		Type of hook
+ * @param returntype	Type of return value
+ * @param thistype		Type of this pointer or ignore (ignore can be used if not needed)
+ * @param callback		Optional callback function, if not set here must be set when hooking.
+ * 
+ * @return Returns setup handle for the hook.
+ * @error Failed to create hook setup handle or invalid callback function.
+*/
+native DynamicHook DHookCreate(int offset, HookType hooktype, ReturnType returntype, ThisPointerType thistype, DHookCallback callback=INVALID_FUNCTION);
+
+/**
+ * Creates a detour
+ *
+ * @param funcaddr		The address of the function to detour.
+ *						Can be Address_Null if you want to load the address from gamedata using DHookSetFromConf.
+ * @param callConv		Calling convention of the function.
+ * @param returnType	Type of the return value.
+ * @param thisType		Type of this pointer or ignore (ignore can be used if not needed)
+ *
+ * @return				Setup handle for the detour.
+ * @error				Failed to create detour setup handle.
+ */	
+native DynamicDetour DHookCreateDetour(Address funcaddr, CallingConvention callConv, ReturnType returntype, ThisPointerType thisType);
+
+/**
+ * Setup a detour or hook for a function as described in a "Functions" section in gamedata.
+ *
+ * @param gameconf		GameConfig handle
+ * @param name			Name of the function in the gamedata to load.
+ *
+ * @return				Setup handle for the detour or INVALID_HANDLE if offset/signature/address wasn't found.
+ * @error				Failed to create detour setup handle, invalid gamedata handle, invalid callback function or failed to find function in gamedata.
+ */
+native DHookSetup DHookCreateFromConf(Handle gameconf, const char[] name);
+
+/**
+ * Load details for a vhook or detour from a gamedata file.
+ *
+ * @param setup			Hook setup handle to set the offset or address on.
+ * @param gameconf		GameConfig handle
+ * @param source		Whether to look in Offsets or Signatures.
+ * @param name			Name of the property to find.
+ *
+ * @return				True on success, false if nothing was found.
+ * @error				Invalid setup or gamedata handle.
+ */
+native bool DHookSetFromConf(Handle setup, Handle gameconf, SDKFuncConfSource source, const char[] name);
+
+/**
+ * Enable the detour of the function described in the hook setup handle.
+ *
+ * @param setup			Hook setup handle
+ * @param post			True to make the hook a post hook. (If you need to change the retunr value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param callback		Callback function
+ *
+ * @return				True if detour was enabled, false otherwise.
+ * @error				Hook handle is not setup for a detour.
+ */
+native bool DHookEnableDetour(Handle setup, bool post, DHookCallback callback);
+
+/**
+ * Disable the detour of the function described in the hook setup handle.
+ *
+ * @param setup			Hook setup handle
+ * @param post			True to disable a post hook.
+ * @param callback		Callback function
+ *
+ * @return				True if detour was disabled, false otherwise.
+ * @error				Hook handle is not setup for a detour or function is not detoured.
+ */
+native bool DHookDisableDetour(Handle setup, bool post, DHookCallback callback);
+
+/* Adds param to a hook setup
+ *
+ * @param setup				Setup handle to add the param to.
+ * @param type				Param type
+ * @param size				Used for Objects (not Object ptr) to define the size of the object.
+ * @param flag				Used to change the pass type.
+ * @param custom_register	The register this argument is passed in instead of the stack.
+ * 
+ * @error	Invalid setup handle or too many params added (request upping the max in thread)
+ * @noreturn
+*/
+native void DHookAddParam(Handle setup, HookParamType type, int size=-1, DHookPassFlag flag=DHookPass_ByVal, DHookRegister custom_register=DHookRegister_Default);
+
+/* Hook entity
+ * 
+ * @param setup			Setup handle to use to add the hook.
+ * @param post			True to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param entity		Entity index to hook on.
+ * @param removalcb		Callback for when the hook is removed (Entity hooks are auto-removed on entity destroyed and will call this callback)
+ * @param callback		Optional callback function, if not set here must be set when creating the hook.
+ * 
+ * @error Invalid setup handle, invalid address, invalid hook type or invalid callback.
+ * @return INVALID_HOOK_ID on fail a hookid on success
+*/
+native int DHookEntity(Handle setup, bool post, int entity, DHookRemovalCB removalcb=INVALID_FUNCTION, DHookCallback callback=INVALID_FUNCTION);
+
+/* Hook gamerules
+ * 
+ * @param setup			Setup handle to use to add the hook.
+ * @param post			True to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param removalcb		Callback for when the hook is removed (Game rules hooks are auto-removed on map end and will call this callback)
+ * @param callback		Optional callback function, if not set here must be set when creating the hook.
+ * 
+ * @error Invalid setup handle, invalid address, invalid hook type or invalid callback.
+ * @return INVALID_HOOK_ID on fail a hookid on success
+*/
+native int DHookGamerules(Handle setup, bool post, DHookRemovalCB removalcb=INVALID_FUNCTION, DHookCallback callback=INVALID_FUNCTION);
+
+/* Hook a raw pointer
+ * 
+ * @param setup			Setup handle to use to add the hook.
+ * @param post			True to make the hook a post hook. (If you need to change the return value or need the return value use a post hook! If you need to change params and return use a pre and post hook!)
+ * @param addr			This pointer address.
+ * @param removalcb		Callback for when the hook is removed (Entity hooks are auto-removed on entity destroyed and will call this callback)
+ * @param callback		Optional callback function, if not set here must be set when creating the hook.
+ * 
+ * @error Invalid setup handle, invalid address, invalid hook type or invalid callback.
+ * @return INVALID_HOOK_ID on fail a hookid on success
+*/
+native int DHookRaw(Handle setup, bool post, Address addr, DHookRemovalCB removalcb=INVALID_FUNCTION, DHookCallback callback=INVALID_FUNCTION);
+
+/* Remove hook by hook id
+ * 
+ * @param hookid		Hook id to remove
+ * 
+ * @return true on success false otherwise
+ * @note This will not fire the removal callback!
+*/
+native bool DHookRemoveHookID(int hookid);
+
+/* Get param value (Use only for: int, entity, bool or float param types)
+ * 
+ * @param hParams		Handle to params structure
+ * @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1. 0 Will return the number of params stored)
+ * 
+ * @error Invalid handle. Invalid param number. Invalid param type.
+ * @return value if num greater than 0. If 0 returns paramcount.
+*/
+native any DHookGetParam(Handle hParams, int num);
+
+/* Get vector param value
+ * 
+ * @param hParams		Handle to params structure
+ * @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
+ * @param vec			Vector buffer to store result.
+ * 
+ * @error Invalid handle. Invalid param number. Invalid param type.
+ * @noreturn
+*/
+native void DHookGetParamVector(Handle hParams, int num, float vec[3]);
+
+/* Get string param value
+ * 
+ * @param hParams		Handle to params structure
+ * @param num			Param number to get. (Example if the function has 2 params and you need the value of the first param num would be 1.)
+ * @param buffer		String buffer to store result
+ * @param size			Buffer size
+ * 
+ * @error Invalid handle. Invalid param number. Invalid param type.
+ * @noreturn
+*/
+native void DHookGetParamString(Handle hParams, int num, char[] buffer, int size);
+
+/* Set param value (Use only for: int, entity, bool or float param types)
+ * 
+ * @param hParams		Handle to params structure
+ * @param num			Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
+ * @param value			Value to set it as (only pass int, bool, float or entity index)
+ * 
+ * @error Invalid handle. Invalid param number. Invalid param type.
+ * @noreturn
+*/
+native void DHookSetParam(Handle hParams, int num, any value);
+
+/* Set vector param value
+ * 
+ * @param hParams		Handle to params structure
+ * @param num			Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
+ * @param vec			Value to set vector as.
+ * 
+ * @error Invalid handle. Invalid param number. Invalid param type.
+ * @noreturn
+*/
+native void DHookSetParamVector(Handle hParams, int num, float vec[3]);
+
+/* Set string param value
+ * 
+ * @param hParams		Handle to params structure
+ * @param num			Param number to set (Example if the function has 2 params and you need to set the value of the first param num would be 1.)
+ * @param value			Value to set string as.
+ * 
+ * @error Invalid handle. Invalid param number. Invalid param type.
+ * @noreturn
+*/
+native void DHookSetParamString(Handle hParams, int num, char[] value);
+
+/* Get return value (Use only for: int, entity, bool or float return types)
+ * 
+ * @param hReturn		Handle to return structure
+ * 
+ * @error Invalid Handle, invalid type.
+ * @return Returns default value if prehook returns actual value if post hook.
+*/
+native any DHookGetReturn(Handle hReturn);
+
+/* Get return vector value
+ * 
+ * @param hReturn		Handle to return structure
+ * @param vec			Vector buffer to store result in. (In pre hooks will be default value (0.0,0.0,0.0))
+ * 
+ * @error Invalid Handle, invalid type.
+ * @noreturn
+*/
+native void DHookGetReturnVector(Handle hReturn, float vec[3]);
+
+/* Get return string value
+ * 
+ * @param hReturn		Handle to return structure
+ * @param buffer		String buffer to store result in. (In pre hooks will be default value "")
+ * @param size			String buffer size
+ * 
+ * @error Invalid Handle, invalid type.
+ * @noreturn
+*/
+native void DHookGetReturnString(Handle hReturn, char[] buffer, int size);
+
+/* Set return value (Use only for: int, entity, bool or float return types)
+ * 
+ * @param hReturn		Handle to return structure
+ * @param value			Value to set return as
+ * 
+ * @error Invalid Handle, invalid type.
+ * @noreturn
+*/
+native void DHookSetReturn(Handle hReturn, any value);
+
+/* Set return vector value
+ * 
+ * @param hReturn		Handle to return structure
+ * @param vec			Value to set return vector as
+ * 
+ * @error Invalid Handle, invalid type.
+ * @noreturn
+*/
+native void DHookSetReturnVector(Handle hReturn, float vec[3]);
+
+/* Set return string value
+ * 
+ * @param hReturn		Handle to return structure
+ * @param value			Value to set return string as
+ * 
+ * @error Invalid Handle, invalid type.
+ * @noreturn
+*/
+native void DHookSetReturnString(Handle hReturn, char[] value);
+
+//WE SHOULD WRAP THESE AROUND STOCKS FOR NON PTR AS WE SUPPORT BOTH WITH THESE NATIVE'S
+
+/* Gets an objects variable value
+ *
+ * @param hParams		Handle to params structure
+ * @param num			Param number to get.
+ * @param offset		Offset within the object to the var to get.
+ * @param type			Type of var it is
+ *
+ * @error Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
+ * @return Value of the objects var. If EHANDLE type or entity returns entity index.
+*/
+native any DHookGetParamObjectPtrVar(Handle hParams, int num, int offset, ObjectValueType type);
+
+/* Sets an objects variable value
+ *
+ * @param hParams		Handle to params structure
+ * @param num			Param number to set.
+ * @param offset		Offset within the object to the var to set.
+ * @param type			Type of var it is
+ * @param value			The value to set the var to.
+ *
+ * @error Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
+ * @noreturn
+*/
+native void DHookSetParamObjectPtrVar(Handle hParams, int num, int offset, ObjectValueType type, any value);
+
+/* Gets an objects vector variable value
+ *
+ * @param hParams		Handle to params structure
+ * @param num			Param number to get.
+ * @param offset		Offset within the object to the var to get.
+ * @param type			Type of var it is
+ * @param buffer		Buffer to store the result vector
+ *
+ * @error Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
+ * @noreturn
+*/
+native void DHookGetParamObjectPtrVarVector(Handle hParams, int num, int offset, ObjectValueType type, float buffer[3]);
+
+/* Sets an objects vector variable value
+ *
+ * @param hParams		Handle to params structure
+ * @param num			Param number to set.
+ * @param offset		Offset within the object to the var to set.
+ * @param type			Type of var it is
+ * @param value			The value to set the vector var to.
+ *
+ * @error Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
+ * @noreturn
+*/
+native void DHookSetParamObjectPtrVarVector(Handle hParams, int num, int offset, ObjectValueType type, float value[3]);
+
+/* Gets an objects string variable value
+ *
+ * @param hParams		Handle to params structure
+ * @param num			Param number to get.
+ * @param offset		Offset within the object to the var to get.
+ * @param type			Type of var it is
+ * @param buffer		Buffer to store the result vector
+ * @param size			Size of the buffer
+ *
+ * @error Invalid handle. Invalid param number. Invalid param type. Invalid Object type.
+ * @noreturn
+*/
+native void DHookGetParamObjectPtrString(Handle hParams, int num, int offset, ObjectValueType type, char[] buffer, int size);
+
+/* Checks if a pointer param is null
+ *
+ * @param hParams		Handle to params structure
+ * @param num			Param number to check.
+ *
+ * @error Non pointer param
+ * @return True if null false otherwise.
+*/
+native bool DHookIsNullParam(Handle hParams, int num);
+
+public Extension __ext_dhooks =
+{
+	name = "dhooks",
+	file = "dhooks.ext",
+#if defined AUTOLOAD_EXTENSIONS
+	autoload = 1,
+#else
+	autoload = 0,
+#endif
+#if defined REQUIRE_EXTENSIONS
+	required = 1,
+#else
+	required = 0,
+#endif
+};
+
+#if !defined REQUIRE_EXTENSIONS
+public __ext_dhooks_SetNTVOptional()
+{
+	MarkNativeAsOptional("DHookAddEntityListener");
+	MarkNativeAsOptional("DHookRemoveEntityListener");
+	MarkNativeAsOptional("DHookCreate");
+	MarkNativeAsOptional("DHookCreateDetour");
+	MarkNativeAsOptional("DHookCreateFromConf");
+	MarkNativeAsOptional("DHookSetFromConf");
+	MarkNativeAsOptional("DHookEnableDetour");
+	MarkNativeAsOptional("DHookDisableDetour");
+	MarkNativeAsOptional("DHookAddParam");
+	MarkNativeAsOptional("DHookEntity");
+	MarkNativeAsOptional("DHookGamerules");
+	MarkNativeAsOptional("DHookRaw");
+	MarkNativeAsOptional("DHookRemoveHookID");
+	MarkNativeAsOptional("DHookGetParam");
+	MarkNativeAsOptional("DHookGetParamVector");
+	MarkNativeAsOptional("DHookGetParamString");
+	MarkNativeAsOptional("DHookSetParam");
+	MarkNativeAsOptional("DHookSetParamVector");
+	MarkNativeAsOptional("DHookSetParamString");
+	MarkNativeAsOptional("DHookGetReturn");
+	MarkNativeAsOptional("DHookGetReturnVector");
+	MarkNativeAsOptional("DHookGetReturnString");
+	MarkNativeAsOptional("DHookSetReturn");
+	MarkNativeAsOptional("DHookSetReturnVector");
+	MarkNativeAsOptional("DHookSetReturnString");
+	MarkNativeAsOptional("DHookGetParamObjectPtrVar");
+	MarkNativeAsOptional("DHookSetParamObjectPtrVar");
+	MarkNativeAsOptional("DHookGetParamObjectPtrVarVector");
+	MarkNativeAsOptional("DHookSetParamObjectPtrVarVector");
+	MarkNativeAsOptional("DHookIsNullParam");
+	MarkNativeAsOptional("DHookGetParamObjectPtrString");
+
+	MarkNativeAsOptional("DHookParam.IsNull");
+	MarkNativeAsOptional("DHookParam.Get");
+	MarkNativeAsOptional("DHookParam.GetVector");
+	MarkNativeAsOptional("DHookParam.GetString");
+	MarkNativeAsOptional("DHookParam.Set");
+	MarkNativeAsOptional("DHookParam.SetVector");
+	MarkNativeAsOptional("DHookParam.SetString");
+	MarkNativeAsOptional("DHookParam.GetObjectVar");
+	MarkNativeAsOptional("DHookParam.GetObjectVarVector");
+	MarkNativeAsOptional("DHookParam.GetObjectVarString");
+	MarkNativeAsOptional("DHookParam.SetObjectVar");
+	MarkNativeAsOptional("DHookParam.SetObjectVarVector");
+	MarkNativeAsOptional("DHookReturn.Value.get");
+	MarkNativeAsOptional("DHookReturn.Value.set");
+	MarkNativeAsOptional("DHookReturn.GetVector");
+	MarkNativeAsOptional("DHookReturn.GetString");
+	MarkNativeAsOptional("DHookReturn.SetVector");
+	MarkNativeAsOptional("DHookReturn.SetString");
+	MarkNativeAsOptional("DHookSetup.SetFromConf");
+	MarkNativeAsOptional("DHookSetup.AddParam");
+	MarkNativeAsOptional("DynamicHook.DynamicHook");
+	MarkNativeAsOptional("DynamicHook.FromConf");
+	MarkNativeAsOptional("DynamicHook.HookEntity");
+	MarkNativeAsOptional("DynamicHook.HookGamerules");
+	MarkNativeAsOptional("DynamicHook.HookRaw");
+	MarkNativeAsOptional("DynamicHook.RemoveHook");
+	MarkNativeAsOptional("DynamicDetour.DynamicDetour");
+	MarkNativeAsOptional("DynamicDetour.FromConf");
+	MarkNativeAsOptional("DynamicDetour.Enable");
+	MarkNativeAsOptional("DynamicDetour.Disable");
+}
+#endif

--- a/addons/sourcemod/scripting/include/movement.inc
+++ b/addons/sourcemod/scripting/include/movement.inc
@@ -111,7 +111,8 @@ stock void Movement_GetOriginEx(int client, float result[3])
 	if (TR_DidHit(trace))
 	{
 		TR_GetEndPosition(result, trace);
-		result[2] = result[2] - 0.03125; // Get rid of the offset (CS:GO quirk?)
+		// Do not get rid of the offset. The offset is correct, as the player must be
+		// at least 0.03125 units away from the ground.
 	}
 	else
 	{

--- a/addons/sourcemod/scripting/include/movementapi.inc
+++ b/addons/sourcemod/scripting/include/movementapi.inc
@@ -79,8 +79,10 @@ forward void Movement_OnStartTouchGround(int client);
  *
  * @param client		Client index.
  * @param jumped		Whether player jumped to leave ground.
+ * @param jumpbug		Whether player performed a jumpbug.
+ * @param ladderJump	Whether player jumped from a ladder.
  */
-forward void Movement_OnStopTouchGround(int client, bool jumped);
+forward void Movement_OnStopTouchGround(int client, bool jumped, bool jumpbug, bool ladderJump);
 
 /**
  * Called when a player starts ducking.
@@ -100,21 +102,152 @@ forward void Movement_OnStopDucking(int client);
  * Called when a player jumps (player_jump event), including 'jumpbugs'.
  * Setting velocity when this is called may not be effective.
  *
- * If the player 'jumpbugs', then they will not call Movement_OnStopTouchGround
- * because their FL_ONGROUND flag was not detected as true prior to the jump.
- *
  * @param client		Client index.
  * @param jumpbug		Whether player 'jumpbugged'.
  */
 forward void Movement_OnPlayerJump(int client, bool jumpbug);
 
 /**
- * Called when a player performs a jumpbug.
- * It is possible to modify velocity when this is called.
+ * Called before Duck movement function is called.
  *
- * @param client 		Client index.
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
  */
-forward void Movement_OnJumpbug(int client);
+forward Action Movement_OnDuckPre(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called after Duck movement function is called.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnDuckPost(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called before LadderMove movement function is called.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnLadderMovePre(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called after LadderMove movement function is called.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnLadderMovePost(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called before FullLadderMove movement function is called.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnFullLadderMovePre(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called after FullLadderMove movement function is called.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnFullLadderMovePost(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called after the player jumps, but before jumping stamina is applied.
+ * Takeoff variables are not set yet. Use this to modify bhop velocity.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnJumpPre(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called after the player jumps and after jumping stamina is applied.
+ * Takeoff variables are already set here.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnJumpPost(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called before AirAccelerate movement function is called.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnAirAcceleratePre(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called after AirAccelerate movement function is called.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnAirAcceleratePost(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called before WalkMove movement function is called.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnWalkMovePre(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called after WalkMove movement function is called.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnWalkMovePost(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called before CategorizePosition movement function is called.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnCategorizePositionPre(int client, float[3] origin, float[3] velocity);
+
+/**
+ * Called after CategorizePosition movement function is called.
+ *
+ * @param client       Client index.
+ * @param origin       Player origin.
+ * @param velocity     Player velocity.
+ * @return             Plugin_Changed if origin or velocity is changed, Plugin_Continue otherwise.
+ */
+forward Action Movement_OnCategorizePositionPost(int client, float[3] origin, float[3] velocity);
 
 // =====[ NATIVES ]=====
 
@@ -277,6 +410,22 @@ native bool Movement_GetDuckbugged(int client);
  */
 native bool Movement_GetJumpbugged(int client);
 
+/**
+ * Get the player's origin during movement processing.
+ *
+ * @param client     Client index.
+ * @param result     Resultant vector.
+ */
+native void Movement_GetRealOrigin(int client, float result[3]);
+
+/**
+ * Get the player's velocity during movement processing.
+ *
+ * @param client     Param description
+ * @param result     Resultant vector.
+ */
+native void Movement_GetRealVelocity(int client, float result[3]);
+
 // =====[ METHODMAP ]=====
 
 methodmap MovementAPIPlayer < MovementPlayer {
@@ -371,6 +520,16 @@ methodmap MovementAPIPlayer < MovementPlayer {
 		public get() {
 			return Movement_GetMaxSpeed(this.ID);
 		}
+	}
+
+	public void GetRealVelocity(float buffer[3])
+	{
+		Movement_GetRealVelocity(this.ID, buffer);
+	}
+	
+	public void GetRealOrigin(float buffer[3])
+	{
+		Movement_GetRealOrigin(this.ID, buffer);
 	}
 }
 

--- a/addons/sourcemod/scripting/include/movementapi.inc
+++ b/addons/sourcemod/scripting/include/movementapi.inc
@@ -25,17 +25,33 @@
 	Perfect Bunnyhop (Perf)
 	When the player has jumped in the tick after landing and keeps their speed.
 
+ 	Duckbug/Crouchbug
+	When the player sucessfully lands due to uncrouching from mid air and not by falling 
+	down. This causes no stamina loss or fall damage upon landing.
+
 	Jumpbug
-	When the player is never seen as 'on ground' when bunnyhopping. This is achievable by 
-	uncrouching and jumping at the same time. A jumpbug results in unusual behaviour such
-	as maintaining horizontal speed and not receiving fall damage.
+ 	This is achieved by duckbugging and jumping at the same time. The player is never seen 
+	as 'on ground' when bunnyhopping from a tick by tick perspective. A jumpbug inherits 
+	the same behavior as a duckbug/crouchbug, along with its effects such as maintaining 
+	speed due to no stamina loss.
 
 	Distbug
-	A distbug can occur when a player lands close to the edge of a block. When calculating
-	the landing position, the source engine will only consider either the horizontal or
-	vertical speed on the very last tick, but not both. The GetNobugLandingOrigin native
-	calculates the correct landing position of the player based on his actual trajectory
-	using all components of the velocity instead.
+	Landing behavior varies depending on whether the player lands close to the edge of a 
+	block or not:
+
+    1. If the player lands close to the edge of a block, this causes the jump duration to 
+	be one tick longer and the player can "slide" on the ground during the landing tick, 
+	using the position post-tick as landing position becomes inaccurate.
+
+    2. On the other hand, if the player does not land close to the edge, the player will 
+	be considered on the ground one tick earlier, using this position as landing position 
+	is not accurate as the player has yet to be fully on the ground.
+ 
+    In scenario 1, GetNobugLandingOrigin calculates the correct landing position of the 
+	player before the sliding effect takes effect.
+
+    In scenario 2, GetNobugLandingOrigin attempts to extrapolate the player's fully on 
+	ground position to make landing positions consistent across scenarios.
 */
 
 
@@ -92,7 +108,13 @@ forward void Movement_OnStopDucking(int client);
  */
 forward void Movement_OnPlayerJump(int client, bool jumpbug);
 
-
+/**
+ * Called when a player performs a jumpbug.
+ * It is possible to modify velocity when this is called.
+ *
+ * @param client 		Client index.
+ */
+forward void Movement_OnJumpbug(int client);
 
 // =====[ NATIVES ]=====
 
@@ -239,7 +261,21 @@ native bool Movement_GetTurningRight(int client);
  */
 native float Movement_GetMaxSpeed(int client);
 
+/**
+ * Gets whether a player duckbugged on this tick.
+ *
+ * @param client		Client index.
+ * @return     			Whether a player duckbugged on this tick.
+ */
+native bool Movement_GetDuckbugged(int client);
 
+/**
+ * Gets whether a player jumpbugged on this tick.
+ *
+ * @param client		Client index.
+ * @return     			Whether a player jumpbugged on this tick.
+ */
+native bool Movement_GetJumpbugged(int client);
 
 // =====[ METHODMAP ]=====
 

--- a/addons/sourcemod/scripting/include/movementapi.inc
+++ b/addons/sourcemod/scripting/include/movementapi.inc
@@ -79,10 +79,10 @@ forward void Movement_OnStartTouchGround(int client);
  *
  * @param client		Client index.
  * @param jumped		Whether player jumped to leave ground.
- * @param jumpbug		Whether player performed a jumpbug.
  * @param ladderJump	Whether player jumped from a ladder.
+ * @param jumpbug		Whether player performed a jumpbug.
  */
-forward void Movement_OnStopTouchGround(int client, bool jumped, bool jumpbug, bool ladderJump);
+forward void Movement_OnStopTouchGround(int client, bool jumped, bool ladderJump, bool jumpbug);
 
 /**
  * Called when a player starts ducking.

--- a/addons/sourcemod/scripting/include/movementapi.inc
+++ b/addons/sourcemod/scripting/include/movementapi.inc
@@ -426,6 +426,38 @@ native void Movement_GetRealOrigin(int client, float result[3]);
  */
 native void Movement_GetRealVelocity(int client, float result[3]);
 
+/**
+ * Set the player's takeoff origin.
+ *
+ * @param client     Client index.
+ * @param origin	 Desired origin.
+ */
+native void Movement_SetTakeoffOrigin(int client, float origin[3]);
+
+/**
+ * Set the player's takeoff velocity.
+ *
+ * @param client     Client index.
+ * @param origin	 Desired velocity.
+ */
+native void Movement_SetTakeoffVelocity(int client, float velocity[3]);
+
+/**
+ * Set the player's landing origin.
+ *
+ * @param client     Client index.
+ * @param origin	 Desired origin.
+ */
+native void Movement_SetLandingOrigin(int client, float origin[3]);
+
+/**
+ * Set the player's landing velocity.
+ *
+ * @param client     Client index.
+ * @param origin	 Desired velocity.
+ */
+native void Movement_SetLandingVelocity(int client, float velocity[3]);
+
 // =====[ METHODMAP ]=====
 
 methodmap MovementAPIPlayer < MovementPlayer {
@@ -453,6 +485,16 @@ methodmap MovementAPIPlayer < MovementPlayer {
 	public void GetTakeoffVelocity(float buffer[3]) {
 		Movement_GetTakeoffVelocity(this.ID, buffer);
 	}
+
+	public void SetTakeoffOrigin(float buffer[3]);
+	{
+		Movement_SetTakeoffOrigin(this.ID, buffer);
+	}
+	
+	public void SetTakeoffVelocity(float buffer[3])
+	{
+		Movement_SetTakeoffVelocity(this.ID, buffer);
+	}
 	
 	property float TakeoffSpeed {
 		public get() {
@@ -478,6 +520,16 @@ methodmap MovementAPIPlayer < MovementPlayer {
 	
 	public void GetLandingVelocity(float buffer[3]) {
 		Movement_GetLandingVelocity(this.ID, buffer);
+	}
+	
+	public void SetLandingOrigin(float buffer[3]);
+	{
+		Movement_SetLandingOrigin(this.ID, buffer);
+	}
+	
+	public void SetLandingVelocity(float buffer[3])
+	{
+		Movement_SetLandingVelocity(this.ID, buffer);
 	}
 	
 	property float LandingSpeed {
@@ -567,5 +619,11 @@ public void __pl_movementapi_SetNTVOptional()
 	MarkNativeAsOptional("Movement_GetTurningLeft");
 	MarkNativeAsOptional("Movement_GetTurningRight");
 	MarkNativeAsOptional("Movement_GetMaxSpeed");
+	MarkNativeAsOptional("Movement_GetRealOrigin");
+	MarkNativeAsOptional("Movement_GetRealVelocity");
+	MarkNativeAsOptional("Movement_SetTakeoffOrigin");
+	MarkNativeAsOptional("Movement_SetTakeoffVelocity");
+	MarkNativeAsOptional("Movement_SetLandingOrigin");
+	MarkNativeAsOptional("Movement_SetLandingVelocity");
 }
 #endif

--- a/addons/sourcemod/scripting/include/movementapi.inc
+++ b/addons/sourcemod/scripting/include/movementapi.inc
@@ -426,6 +426,38 @@ native void Movement_GetRealOrigin(int client, float result[3]);
  */
 native void Movement_GetRealVelocity(int client, float result[3]);
 
+/**
+ * Set the player's takeoff origin.
+ *
+ * @param client     Client index.
+ * @param origin	 Desired origin.
+ */
+native void Movement_SetTakeoffOrigin(int client, float origin[3]);
+
+/**
+ * Set the player's takeoff velocity.
+ *
+ * @param client     Client index.
+ * @param origin	 Desired velocity.
+ */
+native void Movement_SetTakeoffVelocity(int client, float velocity[3]);
+
+/**
+ * Set the player's landing origin.
+ *
+ * @param client     Client index.
+ * @param origin	 Desired origin.
+ */
+native void Movement_SetLandingOrigin(int client, float origin[3]);
+
+/**
+ * Set the player's landing velocity.
+ *
+ * @param client     Client index.
+ * @param origin	 Desired velocity.
+ */
+native void Movement_SetLandingVelocity(int client, float velocity[3]);
+
 // =====[ METHODMAP ]=====
 
 methodmap MovementAPIPlayer < MovementPlayer {
@@ -453,6 +485,16 @@ methodmap MovementAPIPlayer < MovementPlayer {
 	public void GetTakeoffVelocity(float buffer[3]) {
 		Movement_GetTakeoffVelocity(this.ID, buffer);
 	}
+
+	public void SetTakeoffOrigin(float buffer[3])
+	{
+		Movement_SetTakeoffOrigin(this.ID, buffer);
+	}
+	
+	public void SetTakeoffVelocity(float buffer[3])
+	{
+		Movement_SetTakeoffVelocity(this.ID, buffer);
+	}
 	
 	property float TakeoffSpeed {
 		public get() {
@@ -478,6 +520,16 @@ methodmap MovementAPIPlayer < MovementPlayer {
 	
 	public void GetLandingVelocity(float buffer[3]) {
 		Movement_GetLandingVelocity(this.ID, buffer);
+	}
+	
+	public void SetLandingOrigin(float buffer[3])
+	{
+		Movement_SetLandingOrigin(this.ID, buffer);
+	}
+	
+	public void SetLandingVelocity(float buffer[3])
+	{
+		Movement_SetLandingVelocity(this.ID, buffer);
 	}
 	
 	property float LandingSpeed {
@@ -567,5 +619,11 @@ public void __pl_movementapi_SetNTVOptional()
 	MarkNativeAsOptional("Movement_GetTurningLeft");
 	MarkNativeAsOptional("Movement_GetTurningRight");
 	MarkNativeAsOptional("Movement_GetMaxSpeed");
+	MarkNativeAsOptional("Movement_GetRealOrigin");
+	MarkNativeAsOptional("Movement_GetRealVelocity");
+	MarkNativeAsOptional("Movement_SetTakeoffOrigin");
+	MarkNativeAsOptional("Movement_SetTakeoffVelocity");
+	MarkNativeAsOptional("Movement_SetLandingOrigin");
+	MarkNativeAsOptional("Movement_SetLandingVelocity");
 }
 #endif

--- a/addons/sourcemod/scripting/include/movementapi.inc
+++ b/addons/sourcemod/scripting/include/movementapi.inc
@@ -486,7 +486,7 @@ methodmap MovementAPIPlayer < MovementPlayer {
 		Movement_GetTakeoffVelocity(this.ID, buffer);
 	}
 
-	public void SetTakeoffOrigin(float buffer[3]);
+	public void SetTakeoffOrigin(float buffer[3])
 	{
 		Movement_SetTakeoffOrigin(this.ID, buffer);
 	}
@@ -522,7 +522,7 @@ methodmap MovementAPIPlayer < MovementPlayer {
 		Movement_GetLandingVelocity(this.ID, buffer);
 	}
 	
-	public void SetLandingOrigin(float buffer[3]);
+	public void SetLandingOrigin(float buffer[3])
 	{
 		Movement_SetLandingOrigin(this.ID, buffer);
 	}

--- a/addons/sourcemod/scripting/movementapi.sp
+++ b/addons/sourcemod/scripting/movementapi.sp
@@ -24,7 +24,6 @@ Handle gH_GetMaxSpeed;
 int gI_Cmdnum[MAXPLAYERS + 1];
 int gI_TickCount[MAXPLAYERS + 1];
 
-ConVar gCV_sv_gravity;
 bool gB_Jumped[MAXPLAYERS + 1];
 bool gB_HitPerf[MAXPLAYERS + 1];
 float gF_NobugLandingOrigin[MAXPLAYERS + 1][3];
@@ -64,7 +63,6 @@ public void OnPluginStart()
 	CreateGlobalForwards();
 	HookEvent("player_spawn", OnPlayerSpawn, EventHookMode_Post);
 	HookEvent("player_jump", OnPlayerJump, EventHookMode_Post);
-	gCV_sv_gravity = FindConVar("sv_gravity");
 	for (int client = 1; client <= MaxClients; client++)
 	{
 		if (IsClientInGame(client))

--- a/addons/sourcemod/scripting/movementapi.sp
+++ b/addons/sourcemod/scripting/movementapi.sp
@@ -23,7 +23,6 @@ GameData gH_GameData;
 Handle gH_GetMaxSpeed;
 int gI_Cmdnum[MAXPLAYERS + 1];
 int gI_TickCount[MAXPLAYERS + 1];
-bool gB_JustJumped[MAXPLAYERS + 1];
 
 ConVar gCV_sv_gravity;
 bool gB_Jumped[MAXPLAYERS + 1];
@@ -82,92 +81,7 @@ public void OnPluginStart()
 void HookEvents()
 {
 	PrepSDKCalls();
-
-	gH_OnDuck = DynamicDetour.FromConf(gH_GameData, "CCSGameMovement::Duck");
-	if (!gH_OnDuck)
-	{
-		SetFailState("Failed to find CCSGameMovement::Duck config");
-	}
-	if (!gH_OnDuck.Enable(Hook_Pre, DHooks_OnDuck_Pre))
-	{
-		SetFailState("Failed to enable detour on CCSGameMovement::Duck");
-	}
-	if (!gH_OnDuck.Enable(Hook_Post, DHooks_OnDuck_Post))
-	{
-		SetFailState("Failed to enable detour on CCSGameMovement::Duck");
-	}
-
-	gH_OnLadderMove = DynamicDetour.FromConf(gH_GameData, "CGameMovement::LadderMove");
-	if (!gH_OnLadderMove)
-	{
-		SetFailState("Failed to find CGameMovement::LadderMove config");
-	}
-	if (!gH_OnLadderMove.Enable(Hook_Pre, DHooks_OnLadderMove_Pre))
-	{
-		SetFailState("Failed to enable detour on CGameMovement::LadderMove");
-	}
-	if (!gH_OnLadderMove.Enable(Hook_Post, DHooks_OnLadderMove_Post))
-	{
-		SetFailState("Failed to enable detour on CGameMovement::LadderMove");
-	}
-
-	gH_OnFullLadderMove = DynamicDetour.FromConf(gH_GameData, "CGameMovement::FullLadderMove");
-	if (!gH_OnFullLadderMove)
-	{
-		SetFailState("Failed to find CGameMovement::FullLadderMove config");
-	}
-	if (!gH_OnFullLadderMove.Enable(Hook_Pre, DHooks_OnFullLadderMove_Pre))
-	{
-		SetFailState("Failed to enable detour on CGameMovement::FullLadderMove");
-	}
-	if (!gH_OnFullLadderMove.Enable(Hook_Post, DHooks_OnFullLadderMove_Post))
-	{
-		SetFailState("Failed to enable detour on CGameMovement::FullLadderMove");
-	}
-
-	gH_OnAirAccelerate = DynamicDetour.FromConf(gH_GameData, "CGameMovement::AirAccelerate");
-	if (!gH_OnAirAccelerate)
-	{
-		SetFailState("Failed to enable detour on CGameMovement::TryPlayerMove");
-	}
-	if (!gH_OnAirAccelerate.Enable(Hook_Pre, DHooks_OnAirAccelerate_Pre))
-	{
-		SetFailState("Failed to enable detour on CGameMovement::AirAccelerate");
-	}
-	if (!gH_OnAirAccelerate.Enable(Hook_Post, DHooks_OnAirAccelerate_Post))
-	{
-		SetFailState("Failed to enable detour on CGameMovement::AirAccelerate");
-	}
-
-	gH_OnWalkMove = DynamicDetour.FromConf(gH_GameData, "CGameMovement::WalkMove");
-	if (!gH_OnWalkMove)
-	{
-		SetFailState("Failed to find CGameMovement::WalkMove config");
-	}
-	if (!gH_OnWalkMove.Enable(Hook_Post, DHooks_OnWalkMove_Post))
-	{
-		SetFailState("Failed to enable detour on CGameMovement::WalkMove");
-	}
-
-	gH_OnJump = DynamicDetour.FromConf(gH_GameData, "CCSGameMovement::OnJump");
-	if (!gH_OnJump)
-	{
-		SetFailState("Failed to find CCSGameMovement::OnJump config");
-	}
-	if (!gH_OnJump.Enable(Hook_Post, DHooks_OnJump_Post))
-	{
-		SetFailState("Failed to enable detour on CCSGameMovement::OnJump");
-	}
-	
-	gH_OnPlayerMove = DynamicDetour.FromConf(gH_GameData, "CCSGameMovement::PlayerMove");
-	if (!gH_OnPlayerMove)
-	{
-		SetFailState("Failed to find CCSGameMovement::PlayerMove config");
-	}
-	if (!gH_OnPlayerMove.Enable(Hook_Post, DHooks_OnPlayerMove_Post))
-	{
-		SetFailState("Failed to enable detour on CCSGameMovement::PlayerMove");
-	}
+	HookGameMovementFunctions();
 }
 
 public void OnClientPutInServer(int client)
@@ -181,24 +95,17 @@ public void OnPlayerPostThinkPost(int client)
 	{
 		return;
 	}
+	
 	float eyeAngles[3];
 	Movement_GetEyeAngles(client, eyeAngles);
-	bool ducking = Movement_GetDucking(client);	
 	UpdateTurning(client, gF_OldEyeAngles[client], eyeAngles);
-	UpdateDucking(client, gB_OldDucking[client], ducking);
-	UpdateOnGround(client, gI_Cmdnum[client], gI_TickCount[client]);
-	if (Movement_GetMovetype(client) != gMT_OldMovetype[client])
-	{
-		UpdateMovetype(client, gI_Cmdnum[client], gI_TickCount[client]);
-	}
-	gB_JustJumped[client] = false;
+	gF_OldEyeAngles[client] = eyeAngles;
+
 	Movement_GetOrigin(client, gF_OldOrigin[client]);
 	Movement_GetVelocity(client, gF_OldVelocity[client]);
-	gF_OldEyeAngles[client] = eyeAngles;
 	gB_OldOnGround[client] = Movement_GetOnGround(client);
-	gB_OldDucking[client] = ducking;
+	gB_OldDucking[client] = gB_Ducking[client];
 	gMT_OldMovetype[client] = Movement_GetMovetype(client);
-	gB_OldDuckbugged[client] = gB_Duckbugged[client];
 	gB_OldWalkMoved[client] = gB_WalkMoved[client];
 }
 
@@ -211,7 +118,6 @@ public void OnPlayerSpawn(Event event, const char[] name, bool dontBroadcast)
 public void OnPlayerJump(Event event, const char[] name, bool dontBroadcast)
 {
 	int client = GetClientOfUserId(GetEventInt(event, "userid"));
-	gB_JustJumped[client] = true;
 	bool jumpbug = !gB_OldOnGround[client];	
 	Call_OnPlayerJump(client, jumpbug);
 }
@@ -223,6 +129,8 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	gB_Duckbugged[client] = false;
 	gB_WalkMoved[client] = false;
 	gB_Jumpbugged[client] = false;
+	gB_Jumped[client] = false;
+	gB_TakeoffFromLadder[client] = false;
 	return Plugin_Continue;
 }
 
@@ -260,187 +168,27 @@ static void ResetClientData(int client)
 	gB_OldDucking[client] = false;
 	gMT_OldMovetype[client] = MOVETYPE_WALK;
 
-	gB_OldDuckbugged[client] = false;
-	gF_OldPostAAOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
-	gF_OldPostAAVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
-	gB_OldWalkMoved[client] = false;
-
-	gF_PreLadderMoveOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gB_ProcessingLadderMove[client] = false;
 	gF_PreLadderMoveVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
-	gB_ProcessingFullLadderMove[client] = false;
+	gB_TakeoffFromLadder[client] = false;
 	gF_PostLadderMoveOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
-
-	gF_PreDuckOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
-	gB_OnDuck_OnGround[client] = false;
+	gF_PostLadderMoveVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gB_ProcessingDuck[client] = false;
+	gF_PreLadderMoveVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gB_Ducking[client] = false;
+	gB_PrevOnGround[client] = false;
 	gB_Duckbugged[client] = false;
 	gF_PostDuckOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
 
 	gB_Jumpbugged[client] = false;
-	gF_PostJumpVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
-	gF_PostLadderMoveVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
 
 	gB_WalkMoved[client] = false;
-	gF_PostWalkMoveOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
 	gF_PostWalkMoveVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
-
-	gF_PreAAVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
 	gF_PostAAOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
 	gF_PostAAVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	
+	gB_OldWalkMoved[client] = false;
 
-	gF_PlayerMoveVelocity_Post[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
-}
-
-static void UpdateDucking(int client, bool oldDucking, bool ducking)
-{
-	if (ducking && !oldDucking)
-	{
-		Call_OnStartDucking(client);
-	}
-	else if (!ducking && oldDucking)
-	{
-		Call_OnStopDucking(client);
-	}
-}
-
-static void UpdateOnGround(int client, int cmdnum, int tickcount)
-{
-	// GetOriginEx returns an incorrect origin that the player was never on.
-	// Use NoBugLandingOrigin for distbug origin, and GetOrigin for real origin.
-	// GetOriginEx causes ladderhop jumpstats to gain extra airtime.
-	float origin[3];
-	Movement_GetOrigin(client, origin);
-
-	// Need to take into account SlopeFix() being called during PostThink...
-	float velocity[3];
-	float slopeFixAccel[3];
-	Movement_GetVelocity(client, velocity);
-	SubtractVectors(velocity, gF_PlayerMoveVelocity_Post[client], slopeFixAccel);
-
-	// The game can still categorize you as "on ground" while noclipping.
-	// Since no real ground collision happens, we just consider the player as not on ground.
-	bool onGround = Movement_GetOnGround(client) && Movement_GetMovetype(client) != MOVETYPE_NOCLIP;
-
-	// Duckbug is a special case where you can land then jump on the same tick.
-	if (gB_Duckbugged[client])
-	{
-		// On this tick WalkMove can be called instead of AirMove.
-		// Therefore gF_PostAAOrigin can't be used here.
-		// Movement_GetOrigin will results in different landing origins,
-		// depending on whether you jumped or not in this tick.
-		gF_LandingOrigin[client] = gF_PostDuckOrigin[client];
-		AddVectors(gF_PreAAVelocity[client], slopeFixAccel, gF_LandingVelocity[client]);
-		gI_LandingTick[client] = tickcount;
-		gI_LandingCmdNum[client] = cmdnum;
-
-		if (!onGround) // AirMove is called.
-		{
-			// In that case, nobug origin needs to be calculated from last tick's velocity after air accel,
-			// as landing on this tick is caused by Duck() and not AirMove().
-			NobugLandingOrigin(client, gF_PostDuckOrigin[client], gF_OldPostAAVelocity[client], gF_NobugLandingOrigin[client]);
-			gF_TakeoffOrigin[client] = gF_PostDuckOrigin[client];
-			AddVectors(gF_PreAAVelocity[client], slopeFixAccel, gF_TakeoffVelocity[client]);
-			gB_HitPerf[client] = gB_JustJumped[client];
-			gI_TakeoffTick[client] = tickcount;
-			gI_TakeoffCmdNum[client] = cmdnum;
-			gB_Jumped[client] = gB_JustJumped[client];
-			// The player never touches the ground so they can't "leave" it, do not call OnStopTouchGround.
-			Call_OnJumpbug(client);
-		}
-		else // WalkMove is called.
-		{
-			// Did not jumpbug, player fully touched the ground.
-			NobugLandingOrigin(client, gF_PostDuckOrigin[client], gF_PostAAVelocity[client], gF_NobugLandingOrigin[client]);
-			Call_OnStartTouchGround(client);
-		}
-	}
-	else if (onGround && !gB_OldOnGround[client])
-	{
-		// We use PostAAVelocity for nobug origin because AirMove() results in landing.
-		NobugLandingOrigin(client, gF_PostAAOrigin[client], gF_PostAAVelocity[client], gF_NobugLandingOrigin[client]);
-		gF_LandingOrigin[client] = origin;
-		AddVectors(gF_PreAAVelocity[client], slopeFixAccel, gF_LandingVelocity[client]);
-		gI_LandingTick[client] = tickcount;
-		gI_LandingCmdNum[client] = cmdnum;
-		Call_OnStartTouchGround(client);
-	}
-	else if (!onGround && gB_OldOnGround[client])
-	{
-		gI_TakeoffTick[client] = tickcount;
-		gI_TakeoffCmdNum[client] = cmdnum;
-		gB_Jumped[client] = gB_JustJumped[client];
-		gF_TakeoffOrigin[client] = gF_OldOrigin[client];
-		if (gMT_OldMovetype[client] == MOVETYPE_LADDER) // Ladderjump/Ladderhop/Climbing ladder
-		{
-			AddVectors(gF_PreAAVelocity[client], slopeFixAccel, gF_TakeoffVelocity[client]);
-			// Can't perf off ladders.
-			gB_HitPerf[client] = false;
-		}
-		else if (gMT_OldMovetype[client] == MOVETYPE_WALK) 
-		{
-			gF_TakeoffOrigin[client] = gF_OldOrigin[client];
-			if (gB_JustJumped[client]) // Jumping
-			{
-				AddVectors(gF_PreAAVelocity[client], slopeFixAccel, gF_TakeoffVelocity[client]);
-			}
-			else // Falling
-			{
-				// OldVelocity is one tick too early if you walk off a block.
-				AddVectors(gF_PostWalkMoveVelocity[client], slopeFixAccel, gF_TakeoffVelocity[client]);
-			}
-
-			// If you walked on the last tick then clearly it's not going to be a perf.
-			// Can't perf if you don't jump.
-			gB_HitPerf[client] = gB_JustJumped[client] && !gB_OldWalkMoved[client];
-		}
-		else // Noclip and fallback scenarios
-		{
-			gF_TakeoffVelocity[client] = gF_OldVelocity[client];
-			gB_HitPerf[client] = false;
-		}
-		Call_OnStopTouchGround(client, gB_JustJumped[client]);
-	}
-}
-
-static void UpdateMovetype(int client, int cmdnum, int tickcount)
-{
-	switch (Movement_GetMovetype(client))
-	{
-		case MOVETYPE_WALK:
-		{
-			// The only change that should matter is between MOVETYPE_LADDER and MOVETYPE_WALK.
-			if (gMT_OldMovetype[client] == MOVETYPE_LADDER) // Ladder jump or ladder hop
-			{
-				gF_TakeoffVelocity[client] = gF_PostLadderMoveVelocity[client];
-			}
-			else
-			{
-				Movement_GetVelocity(client, gF_TakeoffVelocity[client]);
-			}
-			// PostLadderMoveOrigin should do the same thing as OldOrigin.
-			// The only time it differs is when the player walks off the ground
-			// trying to snap to a ladder behind them, which isn't the case here.
-			gF_TakeoffOrigin[client] = gF_OldOrigin[client];
-			gI_TakeoffTick[client] = tickcount;
-			gI_TakeoffCmdNum[client] = cmdnum;
-			gB_Jumped[client] = gB_JustJumped[client];
-			gB_HitPerf[client] = false;			
-		}
-		case MOVETYPE_LADDER:
-		{
-			Movement_GetOrigin(client, gF_LandingOrigin[client]);
-			gF_LandingVelocity[client] = gF_PreLadderMoveVelocity[client];
-			gI_LandingTick[client] = tickcount;
-			gI_LandingCmdNum[client] = cmdnum;
-		}
-		case MOVETYPE_NOCLIP:
-		{
-			Movement_GetOrigin(client, gF_LandingOrigin[client]);
-			Movement_GetVelocity(client, gF_LandingVelocity[client]);
-			gI_LandingTick[client] = tickcount;
-			gI_LandingCmdNum[client] = cmdnum;
-		}
-	}
-	Call_OnChangeMovetype(client, gMT_OldMovetype[client], Movement_GetMovetype(client));
 }
 
 static void UpdateTurning(int client, const float oldEyeAngles[3], const float eyeAngles[3])
@@ -448,50 +196,4 @@ static void UpdateTurning(int client, const float oldEyeAngles[3], const float e
 	gB_Turning[client] = eyeAngles[1] != oldEyeAngles[1];
 	gB_TurningLeft[client] = eyeAngles[1] < oldEyeAngles[1] - 180
 	 || eyeAngles[1] > oldEyeAngles[1] && eyeAngles[1] < oldEyeAngles[1] + 180;
-}
-
-static void NobugLandingOrigin(int client, const float oldOrigin[3], const float oldVelocity[3], float landingOrigin[3])
-{
-	float firstTraceEndpoint[3], velocity[3];
-	float hullMin[3] =  { -16.0, -16.0, 0.0 };
-	float hullMax[3] =  { 16.0, 16.0, 0.0 };
-	
-	velocity[0] = oldVelocity[0] * GetTickInterval();
-	velocity[1] = oldVelocity[1] * GetTickInterval();
-	velocity[2] = oldVelocity[2] * GetTickInterval();
-	AddVectors(oldOrigin, velocity, firstTraceEndpoint);
-	
-	Handle trace = TR_TraceHullFilterEx(oldOrigin, firstTraceEndpoint, hullMin, hullMax, MASK_PLAYERSOLID, TraceEntityFilterPlayers, client);
-	if (!TR_DidHit(trace))
-	{
-		// Nobug jump, extrapolating landing position
-		delete trace;
-		
-		float secondTraceEndpoint[3];
-		// Movement_GetGravity is not sv_gravity. Normally this is 1 or 0, sometimes 40 on antibhop triggers.		
-		// We will (boldly) assume that player's gravity wasn't changed between OnPlayerRunCmd and PostThink.
-
-		velocity[2] -= GetTickInterval() * GetTickInterval() * gCV_sv_gravity.FloatValue;	
-		AddVectors(firstTraceEndpoint, velocity, secondTraceEndpoint);
-		trace = TR_TraceHullFilterEx(firstTraceEndpoint, secondTraceEndpoint, hullMin, hullMax, MASK_PLAYERSOLID, TraceEntityFilterPlayers, client);
-		
-		// It is possible to not hit the trace, if your vertical velocity is low enough.
-		// In an extreme case, you would need 10 more traces for this to hit.
-		// It is also possible to miss the trace on a flat jump, by hitting the very edge of a block.
-		if (!TR_DidHit(trace))
-		{
-			// Invalidate the landing origin	
-			landingOrigin[0] = 0.0 / 0.0;
-			landingOrigin[1] = 0.0 / 0.0;
-			landingOrigin[2] = 0.0 / 0.0;
-			delete trace;
-			return;
-		}
-	}
-	
-	TR_GetEndPosition(landingOrigin, trace);
-	// The trace is correct, the player will be at least 0.03125 unit above the ground.
-	// So do not subtract the z origin by 0.03125.
-	
-	delete trace;
 }

--- a/addons/sourcemod/scripting/movementapi.sp
+++ b/addons/sourcemod/scripting/movementapi.sp
@@ -315,9 +315,6 @@ static void UpdateOnGround(int client, int cmdnum, int tickcount)
 	Movement_GetVelocity(client, velocity);
 	SubtractVectors(velocity, gF_PlayerMoveVelocity_Post[client], slopeFixAccel);
 
-	// Do not modify vertical velocity. This can cause weird bouncing effect.
-	if (slopeFixAccel[0] != 0 || slopeFixAccel[1] != 0 ||slopeFixAccel[2] != 0) PrintToConsole(client, "slopefixAccel2: %f", slopeFixAccel[2]);
-
 	// The game can still categorize you as "on ground" while noclipping.
 	// Since no real ground collision happens, we just consider the player as not on ground.
 	bool onGround = Movement_GetOnGround(client) && Movement_GetMovetype(client) != MOVETYPE_NOCLIP;

--- a/addons/sourcemod/scripting/movementapi.sp
+++ b/addons/sourcemod/scripting/movementapi.sp
@@ -1,6 +1,7 @@
 #include <sourcemod>
 
 #include <sdkhooks>
+#include <dhooks>
 
 #include <movement>
 
@@ -18,9 +19,8 @@ public Plugin myinfo =
 	url = "https://github.com/danzayau/MovementAPI"
 };
 
-Handle gH_GameData;
+GameData gH_GameData;
 Handle gH_GetMaxSpeed;
-
 int gI_Cmdnum[MAXPLAYERS + 1];
 int gI_TickCount[MAXPLAYERS + 1];
 bool gB_JustJumped[MAXPLAYERS + 1];
@@ -46,10 +46,10 @@ bool gB_OldOnGround[MAXPLAYERS + 1];
 bool gB_OldDucking[MAXPLAYERS + 1];
 MoveType gMT_OldMovetype[MAXPLAYERS + 1];
 
-#include "movementapi/forwards.sp"
+#include "movementapi/stocks.sp"
+#include "movementapi/hooks.sp"
 #include "movementapi/natives.sp"
-
-
+#include "movementapi/forwards.sp"
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)
 {
@@ -60,7 +60,7 @@ public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max
 
 public void OnPluginStart()
 {
-	PrepSDKCalls();
+	HookEvents();
 	CreateGlobalForwards();
 	HookEvent("player_spawn", OnPlayerSpawn, EventHookMode_Post);
 	HookEvent("player_jump", OnPlayerJump, EventHookMode_Post);
@@ -78,9 +78,127 @@ public void OnPluginStart()
 	}
 }
 
+void HookEvents()
+{
+	PrepSDKCalls();
+
+	gH_OnDuck = DynamicDetour.FromConf(gH_GameData, "CCSGameMovement::Duck");
+	if (!gH_OnDuck)
+	{
+		SetFailState("Failed to find CCSGameMovement::Duck config");
+	}
+	if (!gH_OnDuck.Enable(Hook_Pre, DHooks_OnDuck_Pre))
+	{
+		SetFailState("Failed to enable detour on CCSGameMovement::Duck");
+	}
+	if (!gH_OnDuck.Enable(Hook_Post, DHooks_OnDuck_Post))
+	{
+		SetFailState("Failed to enable detour on CCSGameMovement::Duck");
+	}
+
+	gH_OnLadderMove = DynamicDetour.FromConf(gH_GameData, "CGameMovement::LadderMove");
+	if (!gH_OnLadderMove)
+	{
+		SetFailState("Failed to find CGameMovement::LadderMove config");
+	}
+	if (!gH_OnLadderMove.Enable(Hook_Pre, DHooks_OnLadderMove_Pre))
+	{
+		SetFailState("Failed to enable detour on CGameMovement::LadderMove");
+	}
+	if (!gH_OnLadderMove.Enable(Hook_Post, DHooks_OnLadderMove_Post))
+	{
+		SetFailState("Failed to enable detour on CGameMovement::LadderMove");
+	}
+
+	gH_OnFullLadderMove = DynamicDetour.FromConf(gH_GameData, "CGameMovement::FullLadderMove");
+	if (!gH_OnFullLadderMove)
+	{
+		SetFailState("Failed to find CGameMovement::FullLadderMove config");
+	}
+	if (!gH_OnFullLadderMove.Enable(Hook_Pre, DHooks_OnFullLadderMove_Pre))
+	{
+		SetFailState("Failed to enable detour on CGameMovement::FullLadderMove");
+	}
+	if (!gH_OnFullLadderMove.Enable(Hook_Post, DHooks_OnFullLadderMove_Post))
+	{
+		SetFailState("Failed to enable detour on CGameMovement::FullLadderMove");
+	}
+
+	gH_OnAirAccelerate = DynamicDetour.FromConf(gH_GameData, "CGameMovement::AirAccelerate");
+	if (!gH_OnAirAccelerate)
+	{
+		SetFailState("Failed to enable detour on CGameMovement::TryPlayerMove");
+	}
+	if (!gH_OnAirAccelerate.Enable(Hook_Pre, DHooks_OnAirAccelerate_Pre))
+	{
+		SetFailState("Failed to enable detour on CGameMovement::AirAccelerate");
+	}
+	if (!gH_OnAirAccelerate.Enable(Hook_Post, DHooks_OnAirAccelerate_Post))
+	{
+		SetFailState("Failed to enable detour on CGameMovement::AirAccelerate");
+	}
+
+	gH_OnWalkMove = DynamicDetour.FromConf(gH_GameData, "CGameMovement::WalkMove");
+	if (!gH_OnWalkMove)
+	{
+		SetFailState("Failed to find CGameMovement::WalkMove config");
+	}
+	if (!gH_OnWalkMove.Enable(Hook_Post, DHooks_OnWalkMove_Post))
+	{
+		SetFailState("Failed to enable detour on CGameMovement::WalkMove");
+	}
+
+	gH_OnJump = DynamicDetour.FromConf(gH_GameData, "CCSGameMovement::OnJump");
+	if (!gH_OnJump)
+	{
+		SetFailState("Failed to find CCSGameMovement::OnJump config");
+	}
+	if (!gH_OnJump.Enable(Hook_Post, DHooks_OnJump_Post))
+	{
+		SetFailState("Failed to enable detour on CCSGameMovement::OnJump");
+	}
+	
+	gH_OnPlayerMove = DynamicDetour.FromConf(gH_GameData, "CCSGameMovement::PlayerMove");
+	if (!gH_OnPlayerMove)
+	{
+		SetFailState("Failed to find CCSGameMovement::PlayerMove config");
+	}
+	if (!gH_OnPlayerMove.Enable(Hook_Post, DHooks_OnPlayerMove_Post))
+	{
+		SetFailState("Failed to enable detour on CCSGameMovement::PlayerMove");
+	}
+}
+
 public void OnClientPutInServer(int client)
 {
 	SDKHook(client, SDKHook_PostThinkPost, OnPlayerPostThinkPost);
+}
+
+public void OnPlayerPostThinkPost(int client)
+{
+	if (!IsPlayerAlive(client))
+	{
+		return;
+	}
+	float eyeAngles[3];
+	Movement_GetEyeAngles(client, eyeAngles);
+	bool ducking = Movement_GetDucking(client);	
+	UpdateTurning(client, gF_OldEyeAngles[client], eyeAngles);
+	UpdateDucking(client, gB_OldDucking[client], ducking);
+	UpdateOnGround(client, gI_Cmdnum[client], gI_TickCount[client]);
+	if (Movement_GetMovetype(client) != gMT_OldMovetype[client])
+	{
+		UpdateMovetype(client, gI_Cmdnum[client], gI_TickCount[client]);
+	}
+	gB_JustJumped[client] = false;
+	Movement_GetOrigin(client, gF_OldOrigin[client]);
+	Movement_GetVelocity(client, gF_OldVelocity[client]);
+	gF_OldEyeAngles[client] = eyeAngles;
+	gB_OldOnGround[client] = Movement_GetOnGround(client);
+	gB_OldDucking[client] = ducking;
+	gMT_OldMovetype[client] = Movement_GetMovetype(client);
+	gB_OldDuckbugged[client] = gB_Duckbugged[client];
+	gB_OldWalkMoved[client] = gB_WalkMoved[client];
 }
 
 public void OnPlayerSpawn(Event event, const char[] name, bool dontBroadcast)
@@ -93,7 +211,7 @@ public void OnPlayerJump(Event event, const char[] name, bool dontBroadcast)
 {
 	int client = GetClientOfUserId(GetEventInt(event, "userid"));
 	gB_JustJumped[client] = true;
-	bool jumpbug = !gB_OldOnGround[client];
+	bool jumpbug = !gB_OldOnGround[client];	
 	Call_OnPlayerJump(client, jumpbug);
 }
 
@@ -101,37 +219,10 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 {
 	gI_Cmdnum[client] = cmdnum;
 	gI_TickCount[client] = tickcount;
-}
-
-public void OnPlayerPostThinkPost(int client)
-{
-	if (!IsPlayerAlive(client))
-	{
-		return;
-	}
-	
-	float origin[3];
-	Movement_GetOriginEx(client, origin);
-	float velocity[3];
-	Movement_GetVelocity(client, velocity);
-	float eyeAngles[3];
-	Movement_GetEyeAngles(client, eyeAngles);
-	bool onGround = Movement_GetOnGround(client);
-	bool ducking = Movement_GetDucking(client);
-	MoveType movetype = Movement_GetMovetype(client);
-	
-	UpdateTurning(client, gF_OldEyeAngles[client], eyeAngles);
-	UpdateDucking(client, gB_OldDucking[client], ducking);
-	UpdateOnGround(client, gI_Cmdnum[client], gI_TickCount[client], gB_OldOnGround[client], onGround, gF_OldOrigin[client], origin, gF_OldVelocity[client], velocity);
-	UpdateMovetype(client, gI_Cmdnum[client], gI_TickCount[client], gMT_OldMovetype[client], movetype, gF_OldOrigin[client], origin, gF_OldVelocity[client], velocity);
-	
-	gB_JustJumped[client] = false;
-	gF_OldOrigin[client] = origin;
-	gF_OldVelocity[client] = velocity;
-	gF_OldEyeAngles[client] = eyeAngles;
-	gB_OldOnGround[client] = onGround;
-	gB_OldDucking[client] = ducking;
-	gMT_OldMovetype[client] = movetype;
+	gB_Duckbugged[client] = false;
+	gB_WalkMoved[client] = false;
+	gB_Jumpbugged[client] = false;
+	return Plugin_Continue;
 }
 
 float GetMaxSpeed(int client)
@@ -167,6 +258,35 @@ static void ResetClientData(int client)
 	gB_OldOnGround[client] = false;
 	gB_OldDucking[client] = false;
 	gMT_OldMovetype[client] = MOVETYPE_WALK;
+
+	gB_OldDuckbugged[client] = false;
+	gF_OldPostAAOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gF_OldPostAAVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gB_OldWalkMoved[client] = false;
+
+	gF_PreLadderMoveOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gF_PreLadderMoveVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gB_ProcessingFullLadderMove[client] = false;
+	gF_PostLadderMoveOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+
+	gF_PreDuckOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gB_OnDuck_OnGround[client] = false;
+	gB_Duckbugged[client] = false;
+	gF_PostDuckOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+
+	gB_Jumpbugged[client] = false;
+	gF_PostJumpVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gF_PostLadderMoveVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+
+	gB_WalkMoved[client] = false;
+	gF_PostWalkMoveOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gF_PostWalkMoveVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+
+	gF_PreAAVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gF_PostAAOrigin[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+	gF_PostAAVelocity[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
+
+	gF_PlayerMoveVelocity_Post[client] = view_as<float>( { 0.0, 0.0, 0.0 } );
 }
 
 static void UpdateDucking(int client, bool oldDucking, bool ducking)
@@ -181,83 +301,148 @@ static void UpdateDucking(int client, bool oldDucking, bool ducking)
 	}
 }
 
-static void UpdateOnGround(
-	int client, 
-	int cmdnum, 
-	int tickcount, 
-	bool oldOnGround, 
-	bool onGround, 
-	const float oldOrigin[3], 
-	const float origin[3], 
-	const float oldVelocity[3], 
-	const float velocity[3])
+static void UpdateOnGround(int client, int cmdnum, int tickcount)
 {
-	if (onGround && !oldOnGround)
+	// GetOriginEx returns an incorrect origin that the player was never on.
+	// Use NoBugLandingOrigin for distbug origin, and GetOrigin for real origin.
+	// GetOriginEx causes ladderhop jumpstats to gain extra airtime.
+	float origin[3];
+	Movement_GetOrigin(client, origin);
+
+	// Need to take into account SlopeFix() being called during PostThink...
+	float velocity[3];
+	float slopeFixAccel[3];
+	Movement_GetVelocity(client, velocity);
+	SubtractVectors(velocity, gF_PlayerMoveVelocity_Post[client], slopeFixAccel);
+
+	// Do not modify vertical velocity. This can cause weird bouncing effect.
+	if (slopeFixAccel[0] != 0 || slopeFixAccel[1] != 0 ||slopeFixAccel[2] != 0) PrintToConsole(client, "slopefixAccel2: %f", slopeFixAccel[2]);
+
+	// The game can still categorize you as "on ground" while noclipping.
+	// Since no real ground collision happens, we just consider the player as not on ground.
+	bool onGround = Movement_GetOnGround(client) && Movement_GetMovetype(client) != MOVETYPE_NOCLIP;
+
+	// Duckbug is a special case where you can land then jump on the same tick.
+	if (gB_Duckbugged[client])
 	{
-		NobugLandingOrigin(client, oldOrigin, oldVelocity, gF_NobugLandingOrigin[client]);
+		// On this tick WalkMove can be called instead of AirMove.
+		// Therefore gF_PostAAOrigin can't be used here.
+		// Movement_GetOrigin will results in different landing origins,
+		// depending on whether you jumped or not in this tick.
+		gF_LandingOrigin[client] = gF_PostDuckOrigin[client];
+		AddVectors(gF_PreAAVelocity[client], slopeFixAccel, gF_LandingVelocity[client]);
+		gI_LandingTick[client] = tickcount;
+		gI_LandingCmdNum[client] = cmdnum;
+
+		if (!onGround) // AirMove is called.
+		{
+			// In that case, nobug origin needs to be calculated from last tick's velocity after air accel,
+			// as landing on this tick is caused by Duck() and not AirMove().
+			NobugLandingOrigin(client, gF_PostDuckOrigin[client], gF_OldPostAAVelocity[client], gF_NobugLandingOrigin[client]);
+			gF_TakeoffOrigin[client] = gF_PostDuckOrigin[client];
+			AddVectors(gF_PreAAVelocity[client], slopeFixAccel, gF_TakeoffVelocity[client]);
+			gB_HitPerf[client] = gB_JustJumped[client];
+			gI_TakeoffTick[client] = tickcount;
+			gI_TakeoffCmdNum[client] = cmdnum;
+			gB_Jumped[client] = gB_JustJumped[client];
+			// The player never touches the ground so they can't "leave" it, do not call OnStopTouchGround.
+			Call_OnJumpbug(client);
+		}
+		else // WalkMove is called.
+		{
+			// Did not jumpbug, player fully touched the ground.
+			NobugLandingOrigin(client, gF_PostDuckOrigin[client], gF_PostAAVelocity[client], gF_NobugLandingOrigin[client]);
+			Call_OnStartTouchGround(client);
+		}
+	}
+	else if (onGround && !gB_OldOnGround[client])
+	{
+		// We use PostAAVelocity for nobug origin because AirMove() results in landing.
+		NobugLandingOrigin(client, gF_PostAAOrigin[client], gF_PostAAVelocity[client], gF_NobugLandingOrigin[client]);
 		gF_LandingOrigin[client] = origin;
-		gF_LandingVelocity[client] = velocity;
+		AddVectors(gF_PreAAVelocity[client], slopeFixAccel, gF_LandingVelocity[client]);
 		gI_LandingTick[client] = tickcount;
 		gI_LandingCmdNum[client] = cmdnum;
 		Call_OnStartTouchGround(client);
 	}
-	else if (!onGround && oldOnGround)
+	else if (!onGround && gB_OldOnGround[client])
 	{
-		gF_TakeoffOrigin[client] = oldOrigin;
-		gF_TakeoffVelocity[client] = oldVelocity;
 		gI_TakeoffTick[client] = tickcount;
 		gI_TakeoffCmdNum[client] = cmdnum;
-		gB_HitPerf[client] = (gI_TakeoffTick[client] - gI_LandingTick[client]) == 1;
 		gB_Jumped[client] = gB_JustJumped[client];
+		gF_TakeoffOrigin[client] = gF_OldOrigin[client];
+		if (gMT_OldMovetype[client] == MOVETYPE_LADDER) // Ladderjump/Ladderhop/Climbing ladder
+		{
+			AddVectors(gF_PreAAVelocity[client], slopeFixAccel, gF_TakeoffVelocity[client]);
+			// Can't perf off ladders.
+			gB_HitPerf[client] = false;
+		}
+		else if (gMT_OldMovetype[client] == MOVETYPE_WALK) 
+		{
+			gF_TakeoffOrigin[client] = gF_OldOrigin[client];
+			if (gB_JustJumped[client]) // Jumping
+			{
+				AddVectors(gF_PreAAVelocity[client], slopeFixAccel, gF_TakeoffVelocity[client]);
+			}
+			else // Falling
+			{
+				// OldVelocity is one tick too early if you walk off a block.
+				AddVectors(gF_PostWalkMoveVelocity[client], slopeFixAccel, gF_TakeoffVelocity[client]);
+			}
+
+			// If you walked on the last tick then clearly it's not going to be a perf.
+			// Can't perf if you don't jump.
+			gB_HitPerf[client] = gB_JustJumped[client] && !gB_OldWalkMoved[client];
+		}
+		else // Noclip and fallback scenarios
+		{
+			gF_TakeoffVelocity[client] = gF_OldVelocity[client];
+			gB_HitPerf[client] = false;
+		}
 		Call_OnStopTouchGround(client, gB_JustJumped[client]);
 	}
 }
 
-static void UpdateMovetype(
-	int client, 
-	int cmdnum, 
-	int tickcount, 
-	MoveType oldMovetype, 
-	MoveType movetype, 
-	const float oldOrigin[3], 
-	const float origin[3], 
-	const float oldVelocity[3], 
-	const float velocity[3])
+static void UpdateMovetype(int client, int cmdnum, int tickcount)
 {
-	if (movetype != oldMovetype)
+	switch (Movement_GetMovetype(client))
 	{
-		switch (movetype)
+		case MOVETYPE_WALK:
 		{
-			case MOVETYPE_WALK:
+			// The only change that should matter is between MOVETYPE_LADDER and MOVETYPE_WALK.
+			if (gMT_OldMovetype[client] == MOVETYPE_LADDER) // Ladder jump or ladder hop
 			{
-				gF_TakeoffOrigin[client] = oldOrigin;
-				// New velocity because game will adjust the velocity
-				// of the player in some cases (jumping off ladder).
-				gF_TakeoffVelocity[client] = velocity;
-				gI_TakeoffTick[client] = tickcount;
-				gI_TakeoffCmdNum[client] = cmdnum;
-				gB_HitPerf[client] = false;
-				gB_Jumped[client] = false;
+				gF_TakeoffVelocity[client] = gF_PostLadderMoveVelocity[client];
 			}
-			case MOVETYPE_LADDER:
+			else
 			{
-				gF_LandingOrigin[client] = origin;
-				// Old velocity because player loses speed before
-				// their movetype has changed to MOVETYPE_LADDER.
-				gF_LandingVelocity[client] = oldVelocity;
-				gI_LandingTick[client] = tickcount;
-				gI_LandingCmdNum[client] = cmdnum;
+				Movement_GetVelocity(client, gF_TakeoffVelocity[client]);
 			}
-			case MOVETYPE_NOCLIP:
-			{
-				gF_LandingOrigin[client] = origin;
-				gF_LandingVelocity[client] = velocity;
-				gI_LandingTick[client] = tickcount;
-				gI_LandingCmdNum[client] = cmdnum;
-			}
+			// PostLadderMoveOrigin should do the same thing as OldOrigin.
+			// The only time it differs is when the player walks off the ground
+			// trying to snap to a ladder behind them, which isn't the case here.
+			gF_TakeoffOrigin[client] = gF_OldOrigin[client];
+			gI_TakeoffTick[client] = tickcount;
+			gI_TakeoffCmdNum[client] = cmdnum;
+			gB_Jumped[client] = gB_JustJumped[client];
+			gB_HitPerf[client] = false;			
 		}
-		Call_OnChangeMovetype(client, gMT_OldMovetype[client], movetype);
+		case MOVETYPE_LADDER:
+		{
+			Movement_GetOrigin(client, gF_LandingOrigin[client]);
+			gF_LandingVelocity[client] = gF_PreLadderMoveVelocity[client];
+			gI_LandingTick[client] = tickcount;
+			gI_LandingCmdNum[client] = cmdnum;
+		}
+		case MOVETYPE_NOCLIP:
+		{
+			Movement_GetOrigin(client, gF_LandingOrigin[client]);
+			Movement_GetVelocity(client, gF_LandingVelocity[client]);
+			gI_LandingTick[client] = tickcount;
+			gI_LandingCmdNum[client] = cmdnum;
+		}
 	}
+	Call_OnChangeMovetype(client, gMT_OldMovetype[client], Movement_GetMovetype(client));
 }
 
 static void UpdateTurning(int client, const float oldEyeAngles[3], const float eyeAngles[3])
@@ -281,12 +466,12 @@ static void NobugLandingOrigin(int client, const float oldOrigin[3], const float
 	Handle trace = TR_TraceHullFilterEx(oldOrigin, firstTraceEndpoint, hullMin, hullMax, MASK_PLAYERSOLID, TraceEntityFilterPlayers, client);
 	if (!TR_DidHit(trace))
 	{
+		// Nobug jump, extrapolating landing position
 		delete trace;
 		
 		float secondTraceEndpoint[3];
 		velocity[2] -= Movement_GetGravity(client) * GetTickInterval();
 		AddVectors(firstTraceEndpoint, velocity, secondTraceEndpoint);
-		
 		trace = TR_TraceHullFilterEx(firstTraceEndpoint, secondTraceEndpoint, hullMin, hullMax, MASK_PLAYERSOLID, TraceEntityFilterPlayers, client);
 		if (!TR_DidHit(trace))
 		{
@@ -300,9 +485,8 @@ static void NobugLandingOrigin(int client, const float oldOrigin[3], const float
 	}
 	
 	TR_GetEndPosition(landingOrigin, trace);
-	
-	// Fix the offset.
-	landingOrigin[2] -= 0.03125;
+	// The trace is correct, the player will be at least 0.03125 unit above the ground.
+	// So do not subtract the z origin by 0.03125.
 	
 	delete trace;
 }

--- a/addons/sourcemod/scripting/movementapi/forwards.sp
+++ b/addons/sourcemod/scripting/movementapi/forwards.sp
@@ -77,13 +77,13 @@ void Call_OnStartTouchGround(int client)
 	Call_Finish();
 }
 
-void Call_OnStopTouchGround(int client, bool jumped, bool jumpbug, bool ladderJump)
+void Call_OnStopTouchGround(int client, bool jumped, bool ladderJump, bool jumpbug)
 {
 	Call_StartForward(H_OnStopTouchGround);
 	Call_PushCell(client);
 	Call_PushCell(jumped);
-	Call_PushCell(jumpbug);
 	Call_PushCell(ladderJump);
+	Call_PushCell(jumpbug);
 	Call_Finish();
 }
 

--- a/addons/sourcemod/scripting/movementapi/forwards.sp
+++ b/addons/sourcemod/scripting/movementapi/forwards.sp
@@ -111,7 +111,7 @@ Action Call_OnPlayerMovePre(int client, float origin[3], float velocity[3], Acti
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -121,7 +121,7 @@ Action Call_OnPlayerMovePost(int client, float origin[3], float velocity[3], Act
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -131,7 +131,7 @@ Action Call_OnDuckPre(int client, float origin[3], float velocity[3], Action &re
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -141,7 +141,7 @@ Action Call_OnDuckPost(int client, float origin[3], float velocity[3], Action &r
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -151,7 +151,7 @@ Action Call_OnLadderMovePre(int client, float origin[3], float velocity[3], Acti
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -161,7 +161,7 @@ Action Call_OnLadderMovePost(int client, float origin[3], float velocity[3], Act
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -171,7 +171,7 @@ Action Call_OnFullLadderMovePre(int client, float origin[3], float velocity[3], 
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -181,7 +181,7 @@ Action Call_OnFullLadderMovePost(int client, float origin[3], float velocity[3],
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -191,7 +191,7 @@ Action Call_OnJumpPre(int client, float origin[3], float velocity[3], Action &re
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -201,7 +201,7 @@ Action Call_OnJumpPost(int client, float origin[3], float velocity[3], Action &r
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -211,7 +211,7 @@ Action Call_OnAirAcceleratePre(int client, float origin[3], float velocity[3], A
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -221,7 +221,7 @@ Action Call_OnAirAcceleratePost(int client, float origin[3], float velocity[3], 
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -231,7 +231,7 @@ Action Call_OnWalkMovePre(int client, float origin[3], float velocity[3], Action
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -241,7 +241,7 @@ Action Call_OnWalkMovePost(int client, float origin[3], float velocity[3], Actio
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -251,7 +251,7 @@ Action Call_OnCategorizePositionPre(int client, float origin[3], float velocity[
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }
 
@@ -261,6 +261,6 @@ Action Call_OnCategorizePositionPost(int client, float origin[3], float velocity
 	Call_PushCell(client);
 	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
-	Call_Finish();
+	Call_Finish(result);
 	return result;
 }

--- a/addons/sourcemod/scripting/movementapi/forwards.sp
+++ b/addons/sourcemod/scripting/movementapi/forwards.sp
@@ -4,18 +4,56 @@ static Handle H_OnStartTouchGround;
 static Handle H_OnStopTouchGround;
 static Handle H_OnChangeMovetype;
 static Handle H_OnPlayerJump;
-static Handle H_OnJumpbug;
 
+static Handle H_OnPlayerMovePre;
+static Handle H_OnPlayerMovePost;
+static Handle H_OnDuckPre;
+static Handle H_OnDuckPost;
+static Handle H_OnLadderMovePre;
+static Handle H_OnLadderMovePost;
+static Handle H_OnFullLadderMovePre;
+static Handle H_OnFullLadderMovePost;
+static Handle H_OnJumpPre;
+static Handle H_OnJumpPost;
+static Handle H_OnAirAcceleratePre;
+static Handle H_OnAirAcceleratePost;
+static Handle H_OnWalkMovePre;
+static Handle H_OnWalkMovePost;
+static Handle H_OnCategorizePositionPre;
+static Handle H_OnCategorizePositionPost;
 
 void CreateGlobalForwards()
 {
 	H_OnStartDucking = CreateGlobalForward("Movement_OnStartDucking", ET_Ignore, Param_Cell);
 	H_OnStopDucking = CreateGlobalForward("Movement_OnStopDucking", ET_Ignore, Param_Cell);
 	H_OnStartTouchGround = CreateGlobalForward("Movement_OnStartTouchGround", ET_Ignore, Param_Cell);
-	H_OnStopTouchGround = CreateGlobalForward("Movement_OnStopTouchGround", ET_Ignore, Param_Cell, Param_Cell);
+	H_OnStopTouchGround = CreateGlobalForward("Movement_OnStopTouchGround", ET_Ignore, Param_Cell, Param_Cell, Param_Cell, Param_Cell);
 	H_OnChangeMovetype = CreateGlobalForward("Movement_OnChangeMovetype", ET_Ignore, Param_Cell, Param_Cell, Param_Cell);
 	H_OnPlayerJump = CreateGlobalForward("Movement_OnPlayerJump", ET_Ignore, Param_Cell, Param_Cell);
-	H_OnJumpbug = CreateGlobalForward("Movement_OnJumpbug", ET_Ignore, Param_Cell, Param_Cell);
+
+	H_OnPlayerMovePre = CreateGlobalForward("Movement_OnPlayerMovePre", ET_Event, Param_Cell, Param_Array, Param_Array);
+	H_OnPlayerMovePost = CreateGlobalForward("Movement_OnPlayerMovePost", ET_Event, Param_Cell, Param_Array, Param_Array);
+
+	H_OnDuckPre = CreateGlobalForward("Movement_OnDuckPre", ET_Event, Param_Cell, Param_Array, Param_Array);
+	H_OnDuckPost = CreateGlobalForward("Movement_OnDuckPost", ET_Event, Param_Cell, Param_Array, Param_Array);
+	
+	H_OnLadderMovePre = CreateGlobalForward("Movement_OnLadderMovePre", ET_Event, Param_Cell, Param_Array, Param_Array);
+	H_OnLadderMovePost = CreateGlobalForward("Movement_OnLadderMovePost", ET_Event, Param_Cell, Param_Array, Param_Array);
+
+	H_OnFullLadderMovePre = CreateGlobalForward("Movement_OnFullLadderMovePre", ET_Event, Param_Cell, Param_Array, Param_Array);
+	H_OnFullLadderMovePost = CreateGlobalForward("Movement_OnFullLadderMovePost", ET_Event, Param_Cell, Param_Array, Param_Array);
+	
+	H_OnJumpPre = CreateGlobalForward("Movement_OnJumpPre", ET_Event, Param_Cell, Param_Array, Param_Array);
+	H_OnJumpPost = CreateGlobalForward("Movement_OnJumpPost", ET_Event, Param_Cell, Param_Array, Param_Array);
+
+	H_OnAirAcceleratePre = CreateGlobalForward("Movement_OnAirAcceleratePre", ET_Event, Param_Cell, Param_Array, Param_Array);
+	H_OnAirAcceleratePost = CreateGlobalForward("Movement_OnAirAcceleratePost", ET_Event, Param_Cell, Param_Array, Param_Array);
+
+	H_OnWalkMovePre = CreateGlobalForward("Movement_OnWalkMovePre", ET_Event, Param_Cell, Param_Array, Param_Array);
+	H_OnWalkMovePost = CreateGlobalForward("Movement_OnWalkMovePost", ET_Event, Param_Cell, Param_Array, Param_Array);
+
+	H_OnCategorizePositionPre = CreateGlobalForward("Movement_OnCategorizePositionPre", ET_Event, Param_Cell, Param_Array, Param_Array);
+	H_OnCategorizePositionPost = CreateGlobalForward("Movement_OnCategorizePositionPost", ET_Event, Param_Cell, Param_Array, Param_Array);
 }
 
 void Call_OnStartDucking(int client)
@@ -39,20 +77,16 @@ void Call_OnStartTouchGround(int client)
 	Call_Finish();
 }
 
-void Call_OnStopTouchGround(int client, bool jumped)
+void Call_OnStopTouchGround(int client, bool jumped, bool jumpbug, bool ladderJump)
 {
 	Call_StartForward(H_OnStopTouchGround);
 	Call_PushCell(client);
 	Call_PushCell(jumped);
+	Call_PushCell(jumpbug);
+	Call_PushCell(ladderJump);
 	Call_Finish();
 }
 
-void Call_OnJumpbug(int client)
-{
-	Call_StartForward(H_OnJumpbug);
-	Call_PushCell(client);
-	Call_Finish();
-}
 
 void Call_OnChangeMovetype(int client, MoveType oldMovetype, MoveType newMovetype)
 {
@@ -69,4 +103,164 @@ void Call_OnPlayerJump(int client, bool jumpbug)
 	Call_PushCell(client);
 	Call_PushCell(jumpbug);
 	Call_Finish();
+}
+
+Action Call_OnPlayerMovePre(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnPlayerMovePre);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnPlayerMovePost(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnPlayerMovePost);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnDuckPre(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnDuckPre);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnDuckPost(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnDuckPost);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnLadderMovePre(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnLadderMovePre);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnLadderMovePost(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnLadderMovePost);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnFullLadderMovePre(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnFullLadderMovePre);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnFullLadderMovePost(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnFullLadderMovePost);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnJumpPre(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnJumpPre);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnJumpPost(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnJumpPost);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnAirAcceleratePre(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnAirAcceleratePre);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnAirAcceleratePost(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnAirAcceleratePost);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnWalkMovePre(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnWalkMovePre);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnWalkMovePost(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnWalkMovePost);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnCategorizePositionPre(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnCategorizePositionPre);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
+}
+
+Action Call_OnCategorizePositionPost(int client, float origin[3], float velocity[3], Action &result)
+{
+	Call_StartForward(H_OnCategorizePositionPost);
+	Call_PushCell(client);
+	Call_PushArrayEx(origin, 3, SM_PARAM_COPYBACK);
+	Call_PushArrayEx(velocity, 3, SM_PARAM_COPYBACK);
+	Call_Finish();
+	return result;
 }

--- a/addons/sourcemod/scripting/movementapi/forwards.sp
+++ b/addons/sourcemod/scripting/movementapi/forwards.sp
@@ -4,7 +4,7 @@ static Handle H_OnStartTouchGround;
 static Handle H_OnStopTouchGround;
 static Handle H_OnChangeMovetype;
 static Handle H_OnPlayerJump;
-
+static Handle H_OnJumpbug;
 
 
 void CreateGlobalForwards()
@@ -15,6 +15,7 @@ void CreateGlobalForwards()
 	H_OnStopTouchGround = CreateGlobalForward("Movement_OnStopTouchGround", ET_Ignore, Param_Cell, Param_Cell);
 	H_OnChangeMovetype = CreateGlobalForward("Movement_OnChangeMovetype", ET_Ignore, Param_Cell, Param_Cell, Param_Cell);
 	H_OnPlayerJump = CreateGlobalForward("Movement_OnPlayerJump", ET_Ignore, Param_Cell, Param_Cell);
+	H_OnJumpbug = CreateGlobalForward("Movement_OnJumpbug", ET_Ignore, Param_Cell, Param_Cell);
 }
 
 void Call_OnStartDucking(int client)
@@ -43,6 +44,13 @@ void Call_OnStopTouchGround(int client, bool jumped)
 	Call_StartForward(H_OnStopTouchGround);
 	Call_PushCell(client);
 	Call_PushCell(jumped);
+	Call_Finish();
+}
+
+void Call_OnJumpbug(int client)
+{
+	Call_StartForward(H_OnJumpbug);
+	Call_PushCell(client);
 	Call_Finish();
 }
 

--- a/addons/sourcemod/scripting/movementapi/hooks.sp
+++ b/addons/sourcemod/scripting/movementapi/hooks.sp
@@ -1,0 +1,197 @@
+DynamicDetour gH_OnPlayerMove;
+DynamicDetour gH_OnDuck;
+DynamicDetour gH_OnLadderMove;
+DynamicDetour gH_OnFullLadderMove;
+DynamicDetour gH_OnJump;
+DynamicDetour gH_OnAirAccelerate;
+DynamicDetour gH_OnWalkMove;
+
+
+bool gB_OldDuckbugged[MAXPLAYERS + 1];
+float gF_OldPostAAOrigin[MAXPLAYERS + 1][3];
+float gF_OldPostAAVelocity[MAXPLAYERS + 1][3];
+bool gB_OldWalkMoved[MAXPLAYERS + 1];
+
+float gF_PreLadderMoveOrigin[MAXPLAYERS + 1][3];
+float gF_PreLadderMoveVelocity[MAXPLAYERS + 1][3];
+bool gB_ProcessingFullLadderMove[MAXPLAYERS + 1];
+float gF_PostLadderMoveOrigin[MAXPLAYERS + 1][3];
+
+float gF_PreDuckOrigin[MAXPLAYERS + 1][3];
+bool gB_OnDuck_OnGround[MAXPLAYERS + 1];
+bool gB_Duckbugged[MAXPLAYERS + 1];
+float gF_PostDuckOrigin[MAXPLAYERS + 1][3];
+
+bool gB_Jumpbugged[MAXPLAYERS + 1];
+float gF_PostJumpVelocity[MAXPLAYERS + 1][3];
+float gF_PostLadderMoveVelocity[MAXPLAYERS + 1][3];
+
+bool gB_WalkMoved[MAXPLAYERS + 1];
+float gF_PostWalkMoveOrigin[MAXPLAYERS + 1][3];
+float gF_PostWalkMoveVelocity[MAXPLAYERS + 1][3];
+
+float gF_PreAAVelocity[MAXPLAYERS + 1][3];
+float gF_PostAAOrigin[MAXPLAYERS + 1][3];
+float gF_PostAAVelocity[MAXPLAYERS + 1][3];
+
+float gF_PlayerMoveVelocity_Post[MAXPLAYERS + 1][3];
+
+
+public MRESReturn DHooks_OnDuck_Pre(Address pThis)
+{
+	int client = GetClientFromGameMovementAddress(pThis);
+	if (!IsPlayerAlive(client) || IsFakeClient(client) || Movement_GetMovetype(client) == MOVETYPE_NOCLIP)
+	{
+		return MRES_Ignored;
+	}
+	GameMove_GetOrigin(pThis, gF_PreDuckOrigin[client]);
+	gB_OnDuck_OnGround[client] = Movement_GetOnGround(client);
+	return MRES_Ignored;
+}
+
+public MRESReturn DHooks_OnDuck_Post(Address pThis)
+{
+	int client = GetClientFromGameMovementAddress(pThis);
+	if (!IsPlayerAlive(client) || IsFakeClient(client) || Movement_GetMovetype(client) == MOVETYPE_NOCLIP)
+	{
+		return MRES_Ignored;
+	}
+	
+	// Only unducking from mid air can change your on ground state.
+	// The only possible change is from air to ground.
+	if (gB_OnDuck_OnGround[client] != Movement_GetOnGround(client))
+	{
+		gB_Duckbugged[client] = true;
+		// Call on duckbug?
+	}
+	else
+	{
+		gB_Duckbugged[client] = false;
+	}
+	GameMove_GetOrigin(pThis, gF_PostDuckOrigin[client]);
+	return MRES_Ignored;
+}
+
+public MRESReturn DHooks_OnLadderMove_Pre(Address pThis)
+{
+	int client = GetClientFromGameMovementAddress(pThis);
+	if (!IsPlayerAlive(client) || IsFakeClient(client) || Movement_GetMovetype(client) == MOVETYPE_NOCLIP)
+	{
+		return MRES_Ignored;
+	}
+	
+	GameMove_GetOrigin(pThis, gF_PreLadderMoveOrigin[client]);
+	GameMove_GetVelocity(pThis, gF_PreLadderMoveVelocity[client]);
+	return MRES_Ignored;
+}
+
+public MRESReturn DHooks_OnLadderMove_Post(Address pThis, DHookReturn hReturn)
+{
+	// While the movetype changed here, the vertical velocity is not yet updated.
+	// gF_PostLadderMoveVelocity can be incorrect here.
+	int client = GetClientFromGameMovementAddress(pThis);
+	if (!IsPlayerAlive(client) || IsFakeClient(client) || Movement_GetMovetype(client) == MOVETYPE_NOCLIP)
+	{
+		return MRES_Ignored;
+	}
+	
+	GameMove_GetOrigin(pThis, gF_PostLadderMoveOrigin[client]);
+	GameMove_GetVelocity(pThis, gF_PostLadderMoveVelocity[client]);	
+	return MRES_Ignored;
+}
+
+public MRESReturn DHooks_OnFullLadderMove_Pre(Address pThis)
+{
+	int client = GetClientFromGameMovementAddress(pThis);
+	if (!IsPlayerAlive(client) || IsFakeClient(client))
+	{
+		return MRES_Ignored;
+	}
+	gB_ProcessingFullLadderMove[client] = true;
+	return MRES_Ignored;
+}
+
+public MRESReturn DHooks_OnJump_Post(Address pThis, DHookParam hParams)
+{
+	int client = GetClientFromGameMovementAddress(pThis);
+	if (!IsPlayerAlive(client) || IsFakeClient(client))
+	{
+		return MRES_Ignored;
+	}
+	// We need to update LadderMove velocity again in case of jumping.
+	if (gB_ProcessingFullLadderMove[client])
+	{
+		GameMove_GetVelocity(pThis, gF_PostLadderMoveVelocity[client]);
+	}
+	else
+	{
+		GameMove_GetVelocity(pThis, gF_PostJumpVelocity[client]);
+	}
+	// Must be set here for SlopeFix to work in PostThink
+	if (gB_Duckbugged[client])
+	{
+		gB_Jumpbugged[client] = true;
+	}
+	return MRES_Ignored;
+}
+
+public MRESReturn DHooks_OnFullLadderMove_Post(Address pThis)
+{
+	int client = GetClientFromGameMovementAddress(pThis);
+	if (!IsPlayerAlive(client) || IsFakeClient(client) || Movement_GetMovetype(client) == MOVETYPE_NOCLIP)
+	{
+		return MRES_Ignored;
+	}
+	gB_ProcessingFullLadderMove[client] = false;
+	return MRES_Ignored;
+}
+
+public MRESReturn DHooks_OnAirAccelerate_Pre(Address pThis, DHookParam hParams)
+{
+	int client = GetClientFromGameMovementAddress(pThis);
+	if (!IsPlayerAlive(client) || IsFakeClient(client))
+	{
+		return MRES_Ignored;
+	}
+	GameMove_GetVelocity(pThis, gF_PreAAVelocity[client]);
+
+	return MRES_Ignored;
+}
+
+public MRESReturn DHooks_OnAirAccelerate_Post(Address pThis, DHookParam hParams)
+{
+	int client = GetClientFromGameMovementAddress(pThis);
+	if (!IsPlayerAlive(client) || IsFakeClient(client))
+	{
+		return MRES_Ignored;
+	}
+	gF_OldPostAAOrigin[client] = gF_PostAAOrigin[client];
+	gF_OldPostAAVelocity[client] = gF_PostAAVelocity[client];
+	GameMove_GetOrigin(pThis, gF_PostAAOrigin[client]);
+	GameMove_GetVelocity(pThis, gF_PostAAVelocity[client]);
+	return MRES_Ignored;
+}
+
+public MRESReturn DHooks_OnWalkMove_Post(Address pThis)
+{
+	int client = GetClientFromGameMovementAddress(pThis);
+	if (!IsPlayerAlive(client) || IsFakeClient(client))
+	{
+		return MRES_Ignored;
+	}
+	GameMove_GetOrigin(pThis, gF_PostWalkMoveOrigin[client]);
+	GameMove_GetVelocity(pThis, gF_PostWalkMoveVelocity[client]);
+	gB_WalkMoved[client] = true;
+	return MRES_Ignored;
+}
+
+public MRESReturn DHooks_OnPlayerMove_Post(Address pThis)
+{
+	int client = GetClientFromGameMovementAddress(pThis);
+	if (!IsPlayerAlive(client) || IsFakeClient(client))
+	{
+		return MRES_Ignored;
+	}
+	GameMove_GetVelocity(pThis, gF_PlayerMoveVelocity_Post[client]);
+	return MRES_Ignored;
+}

--- a/addons/sourcemod/scripting/movementapi/hooks.sp
+++ b/addons/sourcemod/scripting/movementapi/hooks.sp
@@ -273,7 +273,7 @@ public MRESReturn DHooks_OnJump_Post(Address pThis, DHookParam hParams)
 	gF_TakeoffOrigin[client] = gF_Origin[client];
 	gF_TakeoffVelocity[client] = gF_Velocity[client];
 	gI_TakeoffCmdNum[client] = gI_Cmdnum[client];
-	gI_TakeoffTick[client] = gI_TakeoffTick[client];
+	gI_TakeoffTick[client] = gI_TickCount[client];
 	if (!Movement_GetOnGround(client) && gB_OldOnGround[client] || gB_Jumpbugged[client])
 	{
  		Call_OnStopTouchGround(client, true, gB_Jumpbugged[client], gB_TakeoffFromLadder[client]);

--- a/addons/sourcemod/scripting/movementapi/hooks.sp
+++ b/addons/sourcemod/scripting/movementapi/hooks.sp
@@ -53,6 +53,11 @@ Action UpdateMoveData(Address pThis, int client, Function func)
 	Call_PushArrayEx(gF_Origin[client], 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(gF_Velocity[client], 3, SM_PARAM_COPYBACK);
 	Call_Finish(result);
+	if (result != Plugin_Continue)
+	{
+		GameMove_SetOrigin(pThis, gF_Origin[client]);
+		GameMove_SetVelocity(pThis, gF_Velocity[client]);
+	}
 	return result;
 }
 

--- a/addons/sourcemod/scripting/movementapi/hooks.sp
+++ b/addons/sourcemod/scripting/movementapi/hooks.sp
@@ -196,22 +196,6 @@ public MRESReturn DHooks_OnLadderMove_Post(Address pThis, DHookReturn hReturn)
 	}
 }
 
-public MRESReturn DHooks_OnLadderHop()
-{
-	int client;
-	// Loop through the players and find the relevant player.
-	for (int i = 0; i < MaxClients + 1; i++)
-	{
-		if (gB_ProcessingLadderMove[i])
-		{
-			client = i;
-			break;
-		}
-	}
-	LogMessage("%i nice", client);
-	return MRES_Ignored;
-	// Another way to do this is to find the original address of the function.
-}
 public MRESReturn DHooks_OnFullLadderMove_Pre(Address pThis)
 {
 	int client = GetClientFromGameMovementAddress(pThis);
@@ -292,7 +276,6 @@ public MRESReturn DHooks_OnJump_Post(Address pThis, DHookParam hParams)
 	gI_TakeoffTick[client] = gI_TakeoffTick[client];
 	if (!Movement_GetOnGround(client) && gB_OldOnGround[client] || gB_Jumpbugged[client])
 	{
-		LogMessage("%N's MoveType upon takeoff: %i", client, Movement_GetMovetype(client));
  		Call_OnStopTouchGround(client, true, gB_Jumpbugged[client], gB_TakeoffFromLadder[client]);
 	}
 

--- a/addons/sourcemod/scripting/movementapi/hooks.sp
+++ b/addons/sourcemod/scripting/movementapi/hooks.sp
@@ -271,7 +271,7 @@ public MRESReturn DHooks_OnJump_Post(Address pThis, DHookParam hParams)
 	gI_TakeoffTick[client] = gI_TickCount[client];
 	if (!Movement_GetOnGround(client) && gB_OldOnGround[client] || gB_Jumpbugged[client])
 	{
- 		Call_OnStopTouchGround(client, true, gB_Jumpbugged[client], gB_TakeoffFromLadder[client]);
+ 		Call_OnStopTouchGround(client, true, gB_TakeoffFromLadder[client], gB_Jumpbugged[client]);
 	}
 
 	Action result = UpdateMoveData(pThis, client, Call_OnJumpPost);
@@ -494,7 +494,7 @@ public MRESReturn DHooks_OnCategorizePosition_Post(Address pThis)
 			gI_TakeoffCmdNum[client] = gI_Cmdnum[client];
 			gB_Jumped[client] = false;
 			gB_HitPerf[client] = false;
-			Call_OnStopTouchGround(client, false, false, !gB_WalkMoved[client]);
+			Call_OnStopTouchGround(client, false, !gB_WalkMoved[client], false);
 		}
 	}
 

--- a/addons/sourcemod/scripting/movementapi/hooks.sp
+++ b/addons/sourcemod/scripting/movementapi/hooks.sp
@@ -497,6 +497,8 @@ public MRESReturn DHooks_OnCategorizePosition_Post(Address pThis)
 			}
 			gI_TakeoffTick[client] = gI_TickCount[client];
 			gI_TakeoffCmdNum[client] = gI_Cmdnum[client];
+			gB_Jumped[client] = false;
+			gB_HitPerf[client] = false;
 			Call_OnStopTouchGround(client, false, false, !gB_WalkMoved[client]);
 		}
 	}

--- a/addons/sourcemod/scripting/movementapi/hooks.sp
+++ b/addons/sourcemod/scripting/movementapi/hooks.sp
@@ -53,11 +53,6 @@ Action UpdateMoveData(Address pThis, int client, Function func)
 	Call_PushArrayEx(gF_Origin[client], 3, SM_PARAM_COPYBACK);
 	Call_PushArrayEx(gF_Velocity[client], 3, SM_PARAM_COPYBACK);
 	Call_Finish(result);
-	if (result != Plugin_Continue)
-	{
-		GameMove_SetOrigin(pThis, gF_Origin[client]);
-		GameMove_SetVelocity(pThis, gF_Velocity[client]);
-	}
 	return result;
 }
 

--- a/addons/sourcemod/scripting/movementapi/natives.sp
+++ b/addons/sourcemod/scripting/movementapi/natives.sp
@@ -17,6 +17,8 @@ void CreateNatives()
 	CreateNative("Movement_GetTurningLeft", Native_GetTurningLeft);
 	CreateNative("Movement_GetTurningRight", Native_GetTurningRight);
 	CreateNative("Movement_GetMaxSpeed", Native_GetMaxSpeed);
+	CreateNative("Movement_GetDuckbugged", Native_GetDuckbugged);
+	CreateNative("Movement_GetJumpbugged", Native_GetJumpbugged);
 }
 
 public int Native_GetJumped(Handle plugin, int numParams)
@@ -104,4 +106,14 @@ public int Native_GetMaxSpeed(Handle plugin, int numParams)
 {
 	int client = GetNativeCell(1);
 	return view_as<int>(GetMaxSpeed(client));
+}
+
+public int Native_GetDuckbugged(Handle plugin, int numParams)
+{
+	return view_as<int>(gB_Duckbugged[GetNativeCell(1)]);
+}
+
+public int Native_GetJumpbugged(Handle plugin, int numParams)
+{
+	return view_as<int>(gB_Jumpbugged[GetNativeCell(1)]);
 }

--- a/addons/sourcemod/scripting/movementapi/natives.sp
+++ b/addons/sourcemod/scripting/movementapi/natives.sp
@@ -19,6 +19,8 @@ void CreateNatives()
 	CreateNative("Movement_GetMaxSpeed", Native_GetMaxSpeed);
 	CreateNative("Movement_GetDuckbugged", Native_GetDuckbugged);
 	CreateNative("Movement_GetJumpbugged", Native_GetJumpbugged);
+	CreateNative("Movement_GetRealOrigin", Native_GetRealOrigin);
+	CreateNative("Movement_GetRealVelocity", Native_GetRealVelocity);
 }
 
 public int Native_GetJumped(Handle plugin, int numParams)
@@ -116,4 +118,14 @@ public int Native_GetDuckbugged(Handle plugin, int numParams)
 public int Native_GetJumpbugged(Handle plugin, int numParams)
 {
 	return view_as<int>(gB_Jumpbugged[GetNativeCell(1)]);
+}
+
+public int Native_GetRealOrigin(Handle plugin, int numParams)
+{
+	SetNativeArray(2, gF_Origin[GetNativeCell(1)], 3);
+}
+
+public int Native_GetRealVelocity(Handle plugin, int numParams)
+{
+	SetNativeArray(2, gF_Velocity[GetNativeCell(1)], 3);
 }

--- a/addons/sourcemod/scripting/movementapi/natives.sp
+++ b/addons/sourcemod/scripting/movementapi/natives.sp
@@ -21,6 +21,10 @@ void CreateNatives()
 	CreateNative("Movement_GetJumpbugged", Native_GetJumpbugged);
 	CreateNative("Movement_GetRealOrigin", Native_GetRealOrigin);
 	CreateNative("Movement_GetRealVelocity", Native_GetRealVelocity);
+	CreateNative("Movement_SetTakeoffOrigin", Native_SetTakeoffOrigin);
+	CreateNative("Movement_SetTakeoffVelocity", Native_SetTakeoffVelocity);
+	CreateNative("Movement_SetLandingOrigin", Native_SetLandingOrigin);
+	CreateNative("Movement_SetLandingVelocity", Native_SetLandingVelocity);
 }
 
 public int Native_GetJumped(Handle plugin, int numParams)
@@ -128,4 +132,44 @@ public int Native_GetRealOrigin(Handle plugin, int numParams)
 public int Native_GetRealVelocity(Handle plugin, int numParams)
 {
 	SetNativeArray(2, gF_Velocity[GetNativeCell(1)], 3);
+}
+
+public int Native_SetTakeoffOrigin(Handle plugin, int numParams)
+{
+	float array[3];
+	GetNativeArray(2, array, sizeof(array));
+	for (int i = 0; i < 3; i++)
+	{
+		gF_TakeoffOrigin[GetNativeCell(1)][i] = array[i];
+	}
+}
+
+public int Native_SetTakeoffVelocity(Handle plugin, int numParams)
+{
+	float array[3];
+	GetNativeArray(2, array, sizeof(array));
+	for (int i = 0; i < 3; i++)
+	{
+		gF_TakeoffVelocity[GetNativeCell(1)][i] = array[i];
+	}
+}
+
+public int Native_SetLandingOrigin(Handle plugin, int numParams)
+{
+	float array[3];
+	GetNativeArray(2, array, sizeof(array));
+	for (int i = 0; i < 3; i++)
+	{
+		gF_LandingOrigin[GetNativeCell(1)][i] = array[i];
+	}
+}
+
+public int Native_SetLandingVelocity(Handle plugin, int numParams)
+{
+	float array[3];
+	GetNativeArray(2, array, sizeof(array));
+	for (int i = 0; i < 3; i++)
+	{
+		gF_LandingVelocity[GetNativeCell(1)][i] = array[i];
+	}
 }

--- a/addons/sourcemod/scripting/movementapi/stocks.sp
+++ b/addons/sourcemod/scripting/movementapi/stocks.sp
@@ -1,3 +1,67 @@
+stock void GameMove_SetVelocity(Address addr, float velocity[3])
+{
+	if (velocity[0] != velocity[0] || velocity[1] != velocity[1] || velocity[2] != velocity[2])
+	{
+		return;
+	}
+	static int mvOffset;
+	static int velocityOffset;
+	if (!mvOffset)
+	{
+		char buffer[8];
+		if (!gH_GameData.GetKeyValue("CGameMovement::mv", buffer, sizeof(buffer)))
+		{
+			ThrowError("Failed to get CGameMovement::mv offset.");
+			return;
+		}
+		mvOffset = StringToInt(buffer);
+		if (!gH_GameData.GetKeyValue("CMoveData::m_vecVelocity", buffer, sizeof(buffer)))
+		{
+			ThrowError("Failed to get CMoveData::m_vecVelocity offset.");
+			return;
+		}
+		velocityOffset = StringToInt(buffer);
+	}
+
+	Address mvAddress = view_as<Address>(LoadFromAddress(view_as<Address>(view_as<int>(addr) + mvOffset), NumberType_Int32));
+	// TODO: idk if raw cast works here or not
+	StoreToAddress(view_as<Address>(view_as<int>(mvAddress) + velocityOffset), view_as<int>(velocity[0]), NumberType_Int32);
+	StoreToAddress(view_as<Address>(view_as<int>(mvAddress) + velocityOffset + 4), view_as<int>(velocity[1]), NumberType_Int32);
+	StoreToAddress(view_as<Address>(view_as<int>(mvAddress) + velocityOffset + 8), view_as<int>(velocity[2]), NumberType_Int32);
+}
+
+stock void GameMove_SetOrigin(Address addr, float origin[3])
+{
+	if (origin[0] != origin[0] || origin[1] != origin[1] || origin[2] != origin[2])
+	{
+		return;
+	}
+	static int mvOffset;
+	static int originOffset;
+	if (!mvOffset)
+	{
+		char buffer[8];
+		if (!gH_GameData.GetKeyValue("CGameMovement::mv", buffer, sizeof(buffer)))
+		{
+			ThrowError("Failed to get CGameMovement::mv offset.");
+			return;
+		}
+		mvOffset = StringToInt(buffer);
+		if (!gH_GameData.GetKeyValue("CMoveData::m_vecAbsOrigin", buffer, sizeof(buffer)))
+		{
+			ThrowError("Failed to get CMoveData::m_vecAbsOrigin offset.");
+			return;
+		}
+		originOffset = StringToInt(buffer);
+	}
+
+	Address mvAddress = view_as<Address>(LoadFromAddress(view_as<Address>(view_as<int>(addr) + mvOffset), NumberType_Int32));
+	// TODO: idk if raw cast works here or not
+	StoreToAddress(view_as<Address>(view_as<int>(mvAddress) + originOffset), view_as<int>(origin[0]), NumberType_Int32);
+	StoreToAddress(view_as<Address>(view_as<int>(mvAddress) + originOffset + 4), view_as<int>(origin[1]), NumberType_Int32);
+	StoreToAddress(view_as<Address>(view_as<int>(mvAddress) + originOffset + 8), view_as<int>(origin[2]), NumberType_Int32);
+}
+
 stock void GameMove_GetVelocity(Address addr, float result[3])
 {
 	static int mvOffset;
@@ -116,4 +180,67 @@ stock int GetClientFromGameMovementAddress(Address addr)
 	int offset = StringToInt(buffer);
 	Address playerAddr = view_as<Address>(LoadFromAddress(view_as<Address>(view_as<int>(addr) + offset), NumberType_Int32));
 	return GetEntityFromAddress(playerAddr);
+}
+
+stock void NobugLandingOrigin(int client, const float oldOrigin[3], const float oldVelocity[3], float landingOrigin[3])
+{
+	float firstTraceEndpoint[3], velocity[3];
+	float hullMin[3] =  { -16.0, -16.0, 0.0 };
+	float hullMax[3] =  { 16.0, 16.0, 0.0 };
+	
+	velocity[0] = oldVelocity[0] * GetTickInterval();
+	velocity[1] = oldVelocity[1] * GetTickInterval();
+	velocity[2] = oldVelocity[2] * GetTickInterval();
+	AddVectors(oldOrigin, velocity, firstTraceEndpoint);
+	
+	Handle trace = TR_TraceHullFilterEx(oldOrigin, firstTraceEndpoint, hullMin, hullMax, MASK_PLAYERSOLID, TraceEntityFilterPlayers, client);
+	if (!TR_DidHit(trace))
+	{
+		// Nobug jump, extrapolating landing position
+		delete trace;
+		
+		float secondTraceEndpoint[3];
+		// Movement_GetGravity is not sv_gravity. Normally this is 1 or 0, sometimes 40 on antibhop triggers.		
+		// We will (boldly) assume that player's gravity wasn't changed between OnPlayerRunCmd and PostThink.
+
+		velocity[2] -= GetTickInterval() * GetTickInterval() * gCV_sv_gravity.FloatValue;	
+		AddVectors(firstTraceEndpoint, velocity, secondTraceEndpoint);
+		trace = TR_TraceHullFilterEx(firstTraceEndpoint, secondTraceEndpoint, hullMin, hullMax, MASK_PLAYERSOLID, TraceEntityFilterPlayers, client);
+		
+		// It is possible to not hit the trace, if your vertical velocity is low enough.
+		// In an extreme case, you would need 10 more traces for this to hit.
+		// It is also possible to miss the trace on a flat jump, by hitting the very edge of a block.
+		if (!TR_DidHit(trace))
+		{
+			// Invalidate the landing origin	
+			landingOrigin[0] = 0.0 / 0.0;
+			landingOrigin[1] = 0.0 / 0.0;
+			landingOrigin[2] = 0.0 / 0.0;
+			delete trace;
+			return;
+		}
+	}
+	
+	TR_GetEndPosition(landingOrigin, trace);
+	// The trace is correct, the player will be at least 0.03125 unit above the ground.
+	// So do not subtract the z origin by 0.03125.
+	
+	delete trace;
+}
+
+stock void HookGameMovementFunction(DynamicDetour handle, char[] fName, DHookCallback preCallback, DHookCallback postCallback)
+{
+	handle = DynamicDetour.FromConf(gH_GameData, fName);
+	if (!handle)
+	{
+		SetFailState("Failed to find %s config", fName);
+	}
+	if (!handle.Enable(Hook_Pre, preCallback))
+	{
+		SetFailState("Failed to enable detour on %s", fName);
+	}
+	if (!handle.Enable(Hook_Post, postCallback))
+	{
+		SetFailState("Failed to enable detour on %s", fName);
+	}
 }

--- a/addons/sourcemod/scripting/movementapi/stocks.sp
+++ b/addons/sourcemod/scripting/movementapi/stocks.sp
@@ -1,0 +1,119 @@
+stock void GameMove_GetVelocity(Address addr, float result[3])
+{
+	static int mvOffset;
+	static int velocityOffset;
+	if (!mvOffset)
+	{
+		char buffer[8];
+		if (!gH_GameData.GetKeyValue("CGameMovement::mv", buffer, sizeof(buffer)))
+		{
+			ThrowError("Failed to get CGameMovement::mv offset.");
+			return;
+		}
+		mvOffset = StringToInt(buffer);
+		if (!gH_GameData.GetKeyValue("CMoveData::m_vecVelocity", buffer, sizeof(buffer)))
+		{
+			ThrowError("Failed to get CMoveData::m_vecVelocity offset.");
+			return;
+		}
+		velocityOffset = StringToInt(buffer);
+	}
+
+	Address mvAddress = view_as<Address>(LoadFromAddress(view_as<Address>(view_as<int>(addr) + mvOffset), NumberType_Int32));
+	result[0] = view_as<float>(LoadFromAddress(view_as<Address>(view_as<int>(mvAddress) + velocityOffset), NumberType_Int32));
+	result[1] = view_as<float>(LoadFromAddress(view_as<Address>(view_as<int>(mvAddress) + velocityOffset + 4), NumberType_Int32));
+	result[2] = view_as<float>(LoadFromAddress(view_as<Address>(view_as<int>(mvAddress) + velocityOffset + 8), NumberType_Int32));
+}
+
+stock void GameMove_GetOrigin(Address addr, float result[3])
+{
+	static int mvOffset;
+	static int originOffset;
+	if (!mvOffset)
+	{
+		char buffer[8];
+		if (!gH_GameData.GetKeyValue("CGameMovement::mv", buffer, sizeof(buffer)))
+		{
+			ThrowError("Failed to get CGameMovement::mv offset.");
+			return;
+		}
+		mvOffset = StringToInt(buffer);
+		if (!gH_GameData.GetKeyValue("CMoveData::m_vecAbsOrigin", buffer, sizeof(buffer)))
+		{
+			ThrowError("Failed to get CMoveData::m_vecAbsOrigin offset.");
+			return;
+		}
+		originOffset = StringToInt(buffer);
+	}
+	
+	Address mvAddress = view_as<Address>(LoadFromAddress(view_as<Address>(view_as<int>(addr) + mvOffset), NumberType_Int32));
+	result[0] = view_as<float>(LoadFromAddress(view_as<Address>(view_as<int>(mvAddress) + originOffset), NumberType_Int32));
+	result[1] = view_as<float>(LoadFromAddress(view_as<Address>(view_as<int>(mvAddress) + originOffset + 4), NumberType_Int32));
+	result[2] = view_as<float>(LoadFromAddress(view_as<Address>(view_as<int>(mvAddress) + originOffset + 8), NumberType_Int32));
+}
+
+stock void GameMove_GetEyeAngles(Address addr, float result[3])
+{
+	static int mvOffset;
+	static int viewAngleOffset;
+	if (!mvOffset)
+	{
+		char buffer[8];
+		if (!gH_GameData.GetKeyValue("CGameMovement::mv", buffer, sizeof(buffer)))
+		{
+			ThrowError("Failed to get CGameMovement::mv offset.");
+			return;
+		}
+		mvOffset = StringToInt(buffer);
+		if (!gH_GameData.GetKeyValue("CMoveData::m_viewAngleOffset", buffer, sizeof(buffer)))
+		{
+			ThrowError("Failed to get CMoveData::m_viewAngleOffset offset.");
+			return;
+		}
+		originOffset = StringToInt(buffer);
+	}
+	
+	Address mvAddress = view_as<Address>(LoadFromAddress(view_as<Address>(view_as<int>(addr) + mvOffset), NumberType_Int32));
+	result[0] = view_as<float>(LoadFromAddress(view_as<Address>(view_as<int>(mvAddress) + viewAngleOffset), NumberType_Int32));
+	result[1] = view_as<float>(LoadFromAddress(view_as<Address>(view_as<int>(mvAddress) + viewAngleOffset + 4), NumberType_Int32));
+	result[2] = view_as<float>(LoadFromAddress(view_as<Address>(view_as<int>(mvAddress) + viewAngleOffset + 8), NumberType_Int32));
+}
+
+stock int GetEntityFromAddress(Address pEntity) {
+	static int offs_RefEHandle;
+	if (offs_RefEHandle) {
+		return EntRefToEntIndex(LoadFromAddress(pEntity + view_as<Address>(offs_RefEHandle), NumberType_Int32) | (1 << 31));
+	}
+
+	// if we don't have it already, attempt to lookup offset based on SDK information
+	// CWorld is derived from CBaseEntity so it should have both offsets
+	int offs_angRotation = FindDataMapInfo(0, "m_angRotation"),
+			offs_vecViewOffset = FindDataMapInfo(0, "m_vecViewOffset");
+	if (offs_angRotation == -1) {
+		ThrowError("Could not find offset for ((CBaseEntity) CWorld)::m_angRotation");
+	} else if (offs_vecViewOffset == -1) {
+		ThrowError("Could not find offset for ((CBaseEntity) CWorld)::m_vecViewOffset");
+	} else if ((offs_angRotation + 0x0C) != (offs_vecViewOffset - 0x04)) {
+		char game[32];
+		GetGameFolderName(game, sizeof(game));
+		ThrowError("Could not confirm offset of CBaseEntity::m_RefEHandle "
+				... "(incorrect assumption for game '%s'?)", game);
+	}
+	
+	// offset seems right, cache it for the next call
+	offs_RefEHandle = offs_angRotation + 0x0C;
+	return GetEntityFromAddress(pEntity);
+}
+
+stock int GetClientFromGameMovementAddress(Address addr) 
+{
+	char buffer[8];
+	if (!gH_GameData.GetKeyValue("CGameMovement::player", buffer, sizeof(buffer)))
+	{
+		ThrowError("Failed to get CGameMovement::player offset.");
+		return -1;
+	}
+	int offset = StringToInt(buffer);
+	Address playerAddr = view_as<Address>(LoadFromAddress(view_as<Address>(view_as<int>(addr) + offset), NumberType_Int32));
+	return GetEntityFromAddress(playerAddr);
+}


### PR DESCRIPTION
- Intercept CGameMovement and CCSGameMovement functions to obtain correct values, now requires DHooks 2 with detour support.
- Movement function hooks now fire a pre and post forward
- Removed UpdateOnGround and UpdateMoveType, related forwards are handled via hooks for accurate measurement
- Add GetRealOrigin and GetRealVelocity natives to obtain accurate MoveData values during movement processing
- Add jumpbug and ladderJump to OnStopTouchGround forward
- Move NobugLandingOrigin to stock.sp, add SetRealVelocity and SetRealOrigin for MoveData
- Add duckbug, clarify how distbug works in Readme.
- Add jumpbug forward and duckbug, jumpbug natives.
- Fix various inaccuracies in takeoff and landing origin/velocity, including #21 