### PR TITLE
Update GetPlayerMaxSpeed offset

### DIFF
--- a/addons/sourcemod/gamedata/movementapi.games.txt
+++ b/addons/sourcemod/gamedata/movementapi.games.txt
@@ -95,9 +95,9 @@
 		{
 			"GetPlayerMaxSpeed"
 			{
-				"windows"	"505"
-				"linux"		"506"
-				"mac"		"506"
+				"windows"	"506"
+				"linux"		"507"
+				"mac"		"507"
 			}
 		}
 		"Signatures"


### PR DESCRIPTION
Since yesterday's Operation Riptide release, GetPlayerMaxSpeed offset changed. Can't speak to the others, but this will fix the existing offset.