### PR TITLE
Only reset movement variables inside movement processing

### DIFF
--- a/addons/sourcemod/scripting/movementapi.sp
+++ b/addons/sourcemod/scripting/movementapi.sp
@@ -125,11 +125,6 @@ public Action OnPlayerRunCmd(int client, int &buttons, int &impulse, float vel[3
 	CheckNoclip(client);
 	gI_Cmdnum[client] = cmdnum;
 	gI_TickCount[client] = tickcount;
-	gB_Duckbugged[client] = false;
-	gB_WalkMoved[client] = false;
-	gB_Jumpbugged[client] = false;
-	gB_Jumped[client] = false;
-	gB_TakeoffFromLadder[client] = false;
 	return Plugin_Continue;
 }
 

--- a/addons/sourcemod/scripting/movementapi/hooks.sp
+++ b/addons/sourcemod/scripting/movementapi/hooks.sp
@@ -403,6 +403,13 @@ public MRESReturn DHooks_OnPlayerMove_Pre(Address pThis)
 	{
 		return MRES_Ignored;
 	}
+	
+	gB_Duckbugged[client] = false;
+	gB_WalkMoved[client] = false;
+	gB_Jumpbugged[client] = false;
+	gB_Jumped[client] = false;
+	gB_TakeoffFromLadder[client] = false;
+	
 	Action result = UpdateMoveData(pThis, client, Call_OnPlayerMovePre);
 
 	if (result != Plugin_Continue)


### PR DESCRIPTION
OnPlayerRunCmd does not guarantee movement processing to happen. In bad network conditions, if the server have to rerun more user commands than `sv_maxusrcmdprocessticks`'s value, then movement processing will not occur.

Here's an example of me falling straight down with saveloc, but because I have very bad internet connection, is it possible for me to be frozen in the air for a split second:
https://youtu.be/hVqcXVs3Ug0

This caused issues with perf detection, allowing the player to bypass the perf cap. By putting the movement variables inside movement processing, this shouldn't be happening anymore, hopefully.