### PR TITLE
Fix bugged jumps still happening on edge cases due to floating point error

### DIFF
--- a/addons/sourcemod/scripting/movementapi/hooks.sp
+++ b/addons/sourcemod/scripting/movementapi/hooks.sp
@@ -537,8 +537,11 @@ static void NobugLandingOrigin(int client, float landingOrigin[3])
 	gB_Duckbugged[client] = gB_ProcessingDuck[client];
 	float distanceToGround = gF_Origin[client][2] - groundPos[2];
 	float velocity[3], origin[3];
-	// NOTE: this has to be 0.0. If there's any distance to the ground, then we'll trace it with this one.
-	if (distanceToGround != 0.0 || gB_ProcessingDuck[client])
+	// If there's any distance to the ground, then we'll trace it with this one.
+	
+	// It seems like sometimes the player can end up ever so slighly above this "ground" value,
+	// likely due to floating point precision error. Treat it as a bugged jump as well.
+	if (distanceToGround > 0.001 || gB_ProcessingDuck[client])
 	{
 		// Use the current origin and velocity if we're not touching the ground
 		gF_LandingVelocity[client] = gF_Velocity[client];


### PR DESCRIPTION
Sometimes you land even further than 0.03125u off the ground, most likely because of floating point precision issue.